### PR TITLE
Allow mantella to use alternative openai API-compatible endpoints

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -4,10 +4,12 @@
 ; 	If you are using a Wabbajack modlist, Mod Organizer 2 may be storing your Skyrim folder in MO2\overwrite\Root 
 ; 	If that is the case, try setting this path as your skyrim_folder if pointing to your actual Skyrim folder doesn't work
 ;   If this path is incorrect, casting a spell on an NPC will will only end a conversation
+;   default = C:\Games\Steam\steamapps\common\Skyrim Special Edition
 skyrim_folder = C:\Games\Steam\steamapps\common\Skyrim Special Edition
 
 ; xvasynth_folder:
 ;   The folder you have xVASynth downloaded to (the folder that contains xVASynth.exe)
+;   default = C:\Games\Steam\steamapps\common\xVASynth
 xvasynth_folder = C:\Games\Steam\steamapps\common\xVASynth
 
 ; mod_folder:
@@ -17,6 +19,7 @@ xvasynth_folder = C:\Games\Steam\steamapps\common\xVASynth
 ;   If you are using Vortex, this path needs to be set to your Skyrim\Data folder
 ;   eg C:\Games\Steam\steamapps\common\Skyrim Special Edition\Data
 ;   If this path is incorrect, NPCs will say the same voiceline on repeat
+;   default = C:\Modding\MO2\mods\Mantella
 mod_folder = C:\Modding\MO2\mods\Mantella
 
 
@@ -86,6 +89,13 @@ model = gpt-3.5-turbo
 ; 	The maximum number of sentences returned by the LLM. Lower this value to reduce waffling
 max_response_sentences = 999
 
+; alternative_openai_api_base:
+; If you are using openai's services, leave this alone, otherwise you can change this variable to another base_api that uses openai's api
+; For example, if you have a local llm framework or online framework that allows you to use a different url to access openai api functions, you can enter the base_api url here 
+; Your alternative api_base must support openai's python streaming protocol.  Examples: http://127.0.0.1:5001/v1 for textgenwebui using the default openai extension, or http://localhost:8080/v1 using the default endpoint for Local.ai.  Do NOT use quotes in entering the endpoint.
+; Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running mantella.  Services may vary, read their documentation.
+; Leave this value as none to use the normal openai chat gpt models.
+alternative_openai_api_base = none
 
 [HUD]
 ; subtitles:

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -24,6 +24,7 @@ class ConfigLoader:
 
             self.max_response_sentences = int(config['LanguageModel']['max_response_sentences'])
             self.llm = config['LanguageModel']['model']
+            self.alternative_openai_api_base = config['LanguageModel']['alternative_openai_api_base']
 
             self.xvasynth_process_device = config['Speech']['tts_process_device']
             self.use_cleanup = int(config['Speech']['use_cleanup'])

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -22,6 +22,7 @@ class ConfigLoader:
 
         self.max_response_sentences = int(config['LanguageModel']['max_response_sentences'])
         self.llm = config['LanguageModel']['model']
+        self.alternative_openai_api_base = config['LanguageModel']['alternative_openai_api_base']
 
         self.subtitles_enabled = config['HUD']['subtitles']
 

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -15,6 +15,7 @@ class ChatManager:
         self.mod_folder = config.mod_path
         self.max_response_sentences = config.max_response_sentences
         self.llm = config.llm
+        self.alternative_openai_api_base = config.alternative_openai_api_base
         self.language = config.language
         self.encoding = encoding
         self.subtitles_enabled = config.subtitles_enabled
@@ -123,7 +124,8 @@ class ChatManager:
         sentence = ''
         full_reply = ''
         num_sentences = 0
-        openai.aiosession.set(ClientSession()) # https://github.com/openai/openai-python#async-api
+        if self.alternative_openai_api_base == 'none':
+            openai.aiosession.set(ClientSession()) # https://github.com/openai/openai-python#async-api
         while True:
             try:
                 start_time = time.time()
@@ -170,7 +172,8 @@ class ChatManager:
                             end_conversation = self.game_state_manager.load_data_when_available('_mantella_end_conversation', '')
                             if (num_sentences >= self.max_response_sentences) or (end_conversation.lower() == 'true'):
                                 break
-                await openai.aiosession.get().close()
+                if self.alternative_openai_api_base == 'none':
+                    await openai.aiosession.get().close()
                 break
             except Exception as e:
                 logging.error(f"ChatGPT API Error: {e}")

--- a/src/setup.py
+++ b/src/setup.py
@@ -48,10 +48,12 @@ def initialise(config_file, logging_file, secret_key_file, character_df_file, la
     config = config_loader.ConfigLoader(config_file)
     setup_logging(logging_file)
     setup_openai_secret_key(secret_key_file)
-
+    
     character_df = get_character_df(character_df_file)
     language_info = get_language_info(language_file)
     encoding = tiktoken.encoding_for_model(config.llm)
     token_limit = get_token_limit(config.llm)
+    if config.alternative_openai_api_base != 'none':
+        openai.api_base = config.alternative_openai_api_base
 
     return config, character_df, language_info, encoding, token_limit


### PR DESCRIPTION
-alternative endpoint specified in config.ini

-alternative endpoint must be compatible with openai's streaming chat completion API

-finding and configuring services for alternative endpoints are the responsibility of the end user