### PR TITLE
support openrouter.ai API

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -46,7 +46,7 @@ collecting_thoughts_npc_response = I need to gather my thoughts for a moment
 ; microphone_enabled
 ;   Whether to use microphone input (1) or text input (0)
 ;   Options: 0, 1
-microphone_enabled = 0
+microphone_enabled = 1
 
 ; model_size:
 ; 	The size of the Whisper model used. Some languages require larger models. The base.en model works well enough for English
@@ -88,6 +88,8 @@ listen_timeout = 30
 ; model:
 ; 	Options: gpt-4, gpt-3.5-turbo, gpt-4-32k, gpt-3.5-turbo-16k
 ;   Recommended: gpt-3.5-turbo-16k
+;   If using openrouter.ai, here put the name of the model you want to use with openrouter in openrouter's provided format in its documentation.  Example: meta-llama/llama-2-70b-chat
+;   Default: gpt-3.5-turbo; 
 model = gpt-3.5-turbo
 
 ; max_response_sentences:
@@ -97,7 +99,8 @@ max_response_sentences = 999
 ; alternative_openai_api_base:
 ; If you are using openai's services, leave this alone, otherwise you can change this variable to another base_api that uses openai's api
 ; For example, if you have a local llm framework or online framework that allows you to use a different url to access openai api functions, you can enter the base_api url here 
-; Your alternative api_base must support openai's python streaming protocol.  Examples: http://127.0.0.1:5001/v1 for textgenwebui using the default openai extension, or http://localhost:8080/v1 using the default endpoint for Local.ai.  Do NOT use quotes in entering the endpoint.
+; Your alternative api_base must support openai's python streaming protocol.  Examples: http://127.0.0.1:5001/v1 for textgenwebui using the default openai extension, http://localhost:8080/v1 using the default endpoint for Local.ai, or https://openrouter.ai/api/v1 for openrouter.  
+; Do NOT use quotes in entering the endpoint.
 ; Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running mantella.  Services may vary, read their documentation.
 ; Leave this value as none to use the normal openai chat gpt models.
 alternative_openai_api_base = none

--- a/src/chat_response.py
+++ b/src/chat_response.py
@@ -13,7 +13,7 @@ def chatgpt_api(input_text, messages, llm):
         logging.info('Getting ChatGPT response...')
         try:
             chat_completion = openai.ChatCompletion.create(
-                model=llm, messages=messages
+                model=llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},
             )
         except openai.error.RateLimitError:
             logging.warning('Could not connect to ChatGPT API, retrying in 5 seconds...')

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -129,7 +129,7 @@ class ChatManager:
         while True:
             try:
                 start_time = time.time()
-                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, stream=True,):
+                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},stream=True,):
                     content = chunk["choices"][0].get("delta", {}).get("content")
                     if content is not None:
                         sentence += content

--- a/src/setup.py
+++ b/src/setup.py
@@ -41,7 +41,8 @@ def initialise(config_file, logging_file, secret_key_file, character_df_file, la
             token_limit = 8192
         elif llm == 'gpt-4-32k':
             token_limit = 32768
-
+        else:
+            token_limit = 4096
         logging.info(f"Running Mantella with '{llm}'. The language model chosen can be changed via config.ini\n")
         return token_limit
 
@@ -51,7 +52,10 @@ def initialise(config_file, logging_file, secret_key_file, character_df_file, la
     
     character_df = get_character_df(character_df_file)
     language_info = get_language_info(language_file)
-    encoding = tiktoken.encoding_for_model(config.llm)
+    chosenmodel = config.llm
+    if 'openrouter' in config.alternative_openai_api_base:
+        chosenmodel = 'gpt-3.5-turbo'
+    encoding = tiktoken.encoding_for_model(chosenmodel)
     token_limit = get_token_limit(config.llm)
     if config.alternative_openai_api_base != 'none':
         openai.api_base = config.alternative_openai_api_base


### PR DESCRIPTION
-provide options to support openrouter.ai API by entering its api base as the "alternative_openai_api_base" and its model terminology as the model

-prevent tiktoken from erroring out by setting it to gpt-3.5-turbo if it doesn't recognize the llm model so that config.ini can be simple and just use one field for the model regardless of whether using openrouter or openai.

-add headers to api calls that are required by openrouter; these do not seem to interfere with calls to openai or textgenwebui in testing so seem to be ok to leave in for all API calls without using conditionals [note: perhaps this would be a problem if other services use different headers but I'm not aware of anything else doing this right now, and prefer as much simplicity as possible in the config.ini to reduce troubleshooting and people making mistakes; in the future a PR could be submitted to avoid hardcoding this if necessary, but would require more config.ini options for custom headers]

-Tested with openrouter (llama 70b), textgenwebui and normal gpt-3.5-turbo with no errors