### PR TITLE
Update setup.py to fix int / string error

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -55,6 +55,8 @@ def initialise(config_file, logging_file, secret_key_file, character_df_file, la
             token_limit = 8000
         elif llm == 'palm-2-codechat-bison':
             token_limit = 8000
+        elif llm == 'llama-2-7b-chat':
+            token_limit = 4096
         elif llm == 'llama-2-13b-chat':
             token_limit = 4096
         elif llm == 'llama-2-70b-chat':
@@ -71,8 +73,11 @@ def initialise(config_file, logging_file, secret_key_file, character_df_file, la
             token_limit = 4096
         else:
             logging.info(f"Could not find number of available tokens for {llm}. Defaulting to token count of {custom_token_count} (this number can be changed via the `custom_token_count` setting in config.ini)")
-            token_limit = custom_token_count
-        
+            try:
+                token_limit = int(custom_token_count)
+            except ValueError:
+                logging.error(f"Invalid custom_token_count value: {custom_token_count}. It should be a valid integer. Please update your configuration.")
+                token_limit = 4096  # Default to 4096 in case of an error.
         if token_limit <= 4096:
             logging.info(f"{llm} has a low token count of {token_limit}. For better NPC memories, try changing to a model with a higher token count")
         


### PR DESCRIPTION
-When using custom model, if unrecognized, code presently sets token_limit to custom_token_count, however custom_token_count comes from the config.ini so is cast by default as a string, resulting in an erorr when token_limit is then compared to 4096; at that point token_limit is a string "4096" so cannot be compared to 4096 an integer.

-This fixes that error by casting the string as an int, and if there is an error, throwing an error and setting the token_limit to 4096 by default.

-Also adds llama-7b-chat as a recognized model as well (not just 13 and 70b)