### PR TITLE
Replaced cases of double asterisks with single asterisks

### DIFF
--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -163,6 +163,9 @@ class ChatManager:
         sentence = sentence.replace(']', ')')
         sentence = sentence.replace('{', '(')
         sentence = sentence.replace('}', ')')
+        # local models sometimes get the idea in their head to use double asterisks **like this** in sentences instead of single
+        # this converts double asterisks to single so that they can be filtered out appropriately
+        sentence = sentence.replace('**','*')
         sentence = parse_asterisks_brackets(sentence)
 
         return sentence


### PR DESCRIPTION
Sometimes local models like to give responses contained in double asterisks. These are now handled by the output_manager filters