### PR TITLE
Modded NPCs messaging fixes

### DIFF
--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -53,7 +53,7 @@ class ChatManager:
             os.mkdir(f"{self.mod_folder}/{in_game_voice_folder}/")
 
             self.game_state_manager.write_game_info('_mantella_error_check', 'True')
-            logging.warn("Modded NPC detected. This NPC will work correctly once you restart Skyrim. To learn how to add memory, a background, and a voice model of your choosing to this NPC, see here: https://github.com/art-from-the-machine/Mantella#adding-modded-npcs")
+            logging.warn("Unknown NPC detected. This NPC will be able to speak once you restart Skyrim. To learn how to add memory, a background, and a voice model of your choosing to this NPC, see here: https://github.com/art-from-the-machine/Mantella#adding-modded-npcs")
             input('\nPress any key to exit...')
             sys.exit(0)
 

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -49,9 +49,9 @@ class ChatManager:
         """Save voice model folder to Mantella Spell if it does not already exist"""
         self.in_game_voice_model = in_game_voice_folder
 
-        in_game_volce_folder = f"{self.mod_folder}/{in_game_voice_folder}/"
-        if not os.path.exists(in_game_volce_folder):
-            os.mkdir(in_game_volce_folder)
+        in_game_voice_folder_path = f"{self.mod_folder}/{in_game_voice_folder}/"
+        if not os.path.exists(in_game_voice_folder_path):
+            os.mkdir(in_game_voice_folder_path)
 
             # copy voicelines from one voice folder to this new voice folder
             # this step is needed for Skyrim to acknowledge the folder
@@ -60,7 +60,7 @@ class ChatManager:
                 source_file_path = os.path.join(example_folder, file_name)
 
                 if os.path.isfile(source_file_path):
-                    shutil.copy(source_file_path, in_game_volce_folder)
+                    shutil.copy(source_file_path, in_game_voice_folder_path)
 
             self.game_state_manager.write_game_info('_mantella_error_check', 'True')
             logging.warn("Unknown NPC detected. This NPC will be able to speak once you restart Skyrim. To learn how to add memory, a background, and a voice model of your choosing to this NPC, see here: https://github.com/art-from-the-machine/Mantella#adding-modded-npcs")

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -49,8 +49,18 @@ class ChatManager:
         """Save voice model folder to Mantella Spell if it does not already exist"""
         self.in_game_voice_model = in_game_voice_folder
 
-        if not os.path.exists(f"{self.mod_folder}/{in_game_voice_folder}/"):
-            os.mkdir(f"{self.mod_folder}/{in_game_voice_folder}/")
+        in_game_volce_folder = f"{self.mod_folder}/{in_game_voice_folder}/"
+        if not os.path.exists(in_game_volce_folder):
+            os.mkdir(in_game_volce_folder)
+
+            # copy voicelines from one voice folder to this new voice folder
+            # this step is needed for Skyrim to acknowledge the folder
+            example_folder = f"{self.mod_folder}/MaleNord/"
+            for file_name in os.listdir(example_folder):
+                source_file_path = os.path.join(example_folder, file_name)
+
+                if os.path.isfile(source_file_path):
+                    shutil.copy(source_file_path, in_game_volce_folder)
 
             self.game_state_manager.write_game_info('_mantella_error_check', 'True')
             logging.warn("Unknown NPC detected. This NPC will be able to speak once you restart Skyrim. To learn how to add memory, a background, and a voice model of your choosing to this NPC, see here: https://github.com/art-from-the-machine/Mantella#adding-modded-npcs")


### PR DESCRIPTION
Changed modded NPCs message from "Modded NPC" to "Unknown NPC" in case it is just an NPC Mantella has not encountered before. Added wav and lip files to newly created voice folders in order for Skyrim to recognise them.