### PR TITLE
(DO NOT MERGE) Introduce Koboldcpp support

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -110,6 +110,7 @@ max_response_sentences = 999
 ;       http://127.0.0.1:5001/v1 for textgenwebui using the default openai extension
 ;       http://localhost:8080/v1 using the default endpoint for Local.ai
 ;       https://openrouter.ai/api/v1 for openrouter
+;       http://localhost:5001/api/extra/generate/stream for koboldcpp
 ;   Ensure that you have the correct secret key set in GPT_SECRET_KEY.txt for the service you are using
 ;   Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running mantella
 ;   Leave this value as none to use the normal openai chat gpt models.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ soundfile==0.12.1
 numpy==1.25.0
 scipy==1.11.1
 charset-normalizer==3.2.0
+requests

--- a/src/chat_response.py
+++ b/src/chat_response.py
@@ -3,29 +3,74 @@ import tiktoken
 import logging
 import src.utils as utils
 import time
+import requests
 
 @utils.time_it
 def chatgpt_api(input_text, messages, llm):
+    reply = ""
     if input_text:
         messages.append(
             {"role": "user", "content": input_text},
         )
         logging.info('Getting ChatGPT response...')
         try:
-            chat_completion = openai.ChatCompletion.create(
-                model=llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},
-            )
+            # check if using kobold llm or not, if using kobold as indicated by the alternative_openai_api_base in the config, then we passed that value to "llm" in game_manager for this purpose
+            if 'api/extra/generate/stream' in llm:
+                # need to parse llm to just get the domain stored in llm and then add /api/v1/generate dynamically; note here we are using the non-streaming API for the summary.
+                parts_of_url = llm.split('/')
+                start_of_url = '/'.join(parts[:3])
+                kobold_url = start_of_url + '/api/v1/generate' #'http://localhost:5001/api/v1/generate'
+                # need to convert messages array into a single string prompt for kobold which does not use messages array format
+                formatted_messages = []
+                for message in messages:
+                    role = message["role"]
+                    content = message["content"]
+                    if role == "user":
+                        formatted_messages.append(f"###Instruction: {content}")
+                    elif role == "assistant":
+                        formatted_messages.append(f"###Response: {content}")
+                    elif role == "system":
+                        formatted_messages.append(f"###Instruction: {content}")
+                formatted_messages.append("###Response:")
+                kobold_messages_string = "\n".join(formatted_messages)
+                
+                kobold_data = {
+                    "prompt": kobold_messages_string,
+                    "temperature": 1.0,
+                    "top_p": 0.9,
+                    "max_length": 200,
+                    "rep_pen":1.12
+                }
+
+                # send a POST request to the kobold API
+                response = requests.post(kobold_url, json=kobold_data)
+
+                # check if the request was successful (status code 200)
+                if response.status_code == 200:
+                    try:
+                        # parse the JSON response
+                        data = response.json()
+                        # extract the "text" value from the response and store it in the "reply" variable
+                        reply = data["results"][0]["text"]
+                        messages.append({"role": "assistant", "content": reply},)
+                        logging.info(f"ChatGPT Response: {reply}")
+                        return reply, messages
+                    except ValueError:
+                        print("Error: Failed to parse JSON response")
+                else:
+                    print(f"Error: Request failed with status code {response.status_code}")
+            # if not using kobold then using a openai API based solution
+            else:
+                chat_completion = openai.ChatCompletion.create(
+                    model=llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},
+                )
+                reply = chat_completion.choices[0].message.content
+                messages.append({"role": "assistant", "content": reply},)
+                logging.info(f"ChatGPT Response: {reply}")
+                return reply, messages
         except openai.error.RateLimitError:
             logging.warning('Could not connect to ChatGPT API, retrying in 5 seconds...')
             time.sleep(5)
-    
-    reply = chat_completion.choices[0].message.content
-    messages.append(
-        {"role": "assistant", "content": chat_completion.choices[0].message.content},
-    )
-    logging.info(f"ChatGPT Response: {reply}")
-
-    return reply, messages
 
 
 def num_tokens_from_messages(messages, model="gpt-3.5-turbo"):

--- a/src/chat_response.py
+++ b/src/chat_response.py
@@ -18,7 +18,7 @@ def chatgpt_api(input_text, messages, llm):
             if 'api/extra/generate/stream' in llm:
                 # need to parse llm to just get the domain stored in llm and then add /api/v1/generate dynamically; note here we are using the non-streaming API for the summary.
                 parts_of_url = llm.split('/')
-                start_of_url = '/'.join(parts[:3])
+                start_of_url = '/'.join(parts_of_url[:3])
                 kobold_url = start_of_url + '/api/v1/generate' #'http://localhost:5001/api/v1/generate'
                 # need to convert messages array into a single string prompt for kobold which does not use messages array format
                 formatted_messages = []

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -320,8 +320,11 @@ class GameStateManager:
 
         messages.append({"role": "user", "content": config.end_conversation_keyword+'.'})
         messages.append({"role": "assistant", "content": config.end_conversation_keyword+'.'})
-
-        character.save_conversation(encoding, messages, tokens_available, config.llm)
+        llm_choice = config.llm
+        # check if using kobold or not, and if so pass kobold through as the llm choice so character_manager and chat_response can use kobold to generate summary instead of chatgpt
+        if 'api/extra/generate/stream' in config.alternative_openai_api_base:
+            llm_choice = config.alternative_openai_api_base
+        character.save_conversation(encoding, messages, tokens_available, llm_choice)
         logging.info('Conversation ended.')
 
         self.write_game_info('_mantella_in_game_events', '')

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -257,7 +257,6 @@ class ChatManager:
                                     for entry in split_response:
                                         # we only want to parse the content of lines that start with data.  If that's not what we have, skip.
                                         if not 'data: {' in entry:
-                                            logging.info("Skipping line because does not have data: { in it")
                                             continue
                                         # entry[6:] should mean we are left with the dictionary after data: in the response because that's all we're parsing at this point
                                         response_token = entry[6:].strip()


### PR DESCRIPTION
-Presently koboldcpp does not use the openai API format and requires custom coding.  This PR preserves the code that will be necessary to implement koboldcpp (which is used by Herika) if koboldcpp does not provide an openai API endpoint.  Currently the dev of koboldcpp indicates it will support an openai API endpoint on the next release (see https://github.com/LostRuins/koboldcpp/issues/450) so this PR should not be merged yet.

The PR does the following:

(1) Adds a requirement of the requests module to requirements.txt.  This is needed for the chat_response file for kobold.cpp to create summaries.

(2) Adds an example of adding the default streaming koboldcpp endpoint to the config.ini.

(3) Adds changes to the chat_response.py file necessary to divert summary requests to kobold when user uses kobold.  The fact the user is using kobold is passed through the game manager's llm variable; game manager checks the content of the alternative_openai_api_base variable and if it fits kobold's unique pattern, feeds the endpoint through to character manager and chat_response to be used for the summary.  Chat response uses the non-streaming kobold endpoint since mantella expects a single response with the summary.

(4) adds changes to the output manager (which now needs to import all of aiohttp instead of just ClientSession) to support streaming SSE responses from koboldcpp's api/v1/extra/generate/stream endpoint which follows its own unique SSE query and response format.  It also parses the messages array used by mantella to take out the openai formating and produce a single prompt string, adding ###Instruction and ###Response keywords usually used by a lot of local LLMs.