### PR TITLE
misc non-breaking changes to support future koboldcpp openai API support

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -108,6 +108,7 @@ max_response_sentences = 999
 ;   Your alternative api_base must support openai's python streaming protocol.
 ;   Examples: 
 ;       http://127.0.0.1:5001/v1 for textgenwebui using the default openai extension
+;       http://127.0.0.1:5001/v1 for koboldcpp (after version 1.46 of koboldcpp which supports the openai API)
 ;       http://localhost:8080/v1 using the default endpoint for Local.ai
 ;       https://openrouter.ai/api/v1 for openrouter
 ;   Ensure that you have the correct secret key set in GPT_SECRET_KEY.txt for the service you are using

--- a/src/chat_response.py
+++ b/src/chat_response.py
@@ -13,7 +13,7 @@ def chatgpt_api(input_text, messages, llm):
         logging.info('Getting ChatGPT response...')
         try:
             chat_completion = openai.ChatCompletion.create(
-                model=llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},
+                model=llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'}, max_tokens=300
             )
         except openai.error.RateLimitError:
             logging.warning('Could not connect to ChatGPT API, retrying in 5 seconds...')

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -187,7 +187,7 @@ class ChatManager:
         while True:
             try:
                 start_time = time.time()
-                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},stream=True,):
+                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},stream=True,stop=['#']):
                     content = chunk["choices"][0].get("delta", {}).get("content")
                     if content is not None:
                         sentence += content


### PR DESCRIPTION
-add stop=['#'] parameter in output_manager to call to openai API to stop models from repeating a ###Instruction: format in their responses sometimes used by non-GPT models using a framework that utilizes the openai API .  Once this character is generated the model will stop generating and then because it will be too short to be its own sentence, mantella's other cleanup code naturally deletes it.

-Adding max_tokens=300 in chat response as an openai parameter to allow the summary enough tokens to summarize but without eating too many tokens.  This also helps with koboldcpp where the default max tokens length is 80, which is nice to keep responses pithy but not long enough for full summaries sometimes.

-add line to config.ini to provide an example of the IP address to use for koboldcpp (either the in-dev version I circulated on discord or the future official 1.46 release as this will not change)