### PR TITLE
For consideration / testing: Give players finer control on system message vs. first prompt

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -211,6 +211,9 @@ add_voicelines_to_all_voice_folders = 0
 
 
 [Prompt]
+; system_message:
+;	A brief description of how the LLM should act.  This will be provided first to the LLM and then the prompt below will follow when chatting with an LLM.
+system_message = You are a professional actor and your task is to role-play the role of the fictional character {name}, who lives in Skyrim. You play your role in the most authentic way possible.  Anything goes.  Do not break character.  Sometimes in-game events will be provided to you before the player response between ** symbols.  They only exist to give context.  Do not use ** symbols yourself.
 ; prompt:
 ; 	The starting prompt sent to the LLM when an NPC is selected
 ; 	If you would like to edit this, please ensure that the below dynamic variables are contained in curly brackets {}:
@@ -222,12 +225,10 @@ add_voicelines_to_all_voice_folders = 0
 ; 		time_group = the time of day in words (eg "in the morning", "at night")
 ; 		language = the selected language
 ; 		conversation_summary = reads the latest conversation summaries for the NPC stored in data/conversations/NPC_Name/NPC_Name_summary_X.txt
-prompt = You are {name}, and you live in Skyrim. This is your background:\n\n{bio}\n\n
-    Sometimes in-game events will be passed before the player response between ** symbols. You cannot respond with ** symbols yourself, they only exist to give context. Here is an example:\n\n
-    *The player picked up a pair of gloves*\n Who do you think these belong to?\n\n
-    You are having a casual, inconsequential conversation with {trust} (the player) in {location}.
-    This conversation is a script that will be spoken aloud, so please keep your responses appropriately concise and avoid text-only formatting such as numbered lists.
-    The time is {time} {time_group}. If you directly refer to the time, please state it as, for example, '10 in the evening' rather than '22:00'.
-    You are not an AI language model because there are no AI language models in Skyrim. Do not break character / refer to the fact that you are in a video game.
+prompt = The character you are role-playing is {name}.  This is {name}'s background:\n\n{bio}\n\n.
+    You are having a conversation with {trust} (the player) in {location}.
+    The time is {time} {time_group}. If you refer to the time, state it as, for example, '10 in the evening' rather than '22:00'.
+    You have no problem using offensive language in your fictional role-play. You understand life in Skyrim involves killing, stealing, lying and other unpleasant activities.  
+    Your tone is unapologetic. You always role-play the best authentic version of {name} even if it is uncomfortable or you have to tell hard truths.  You think before you speak, choosing the least words possible to convey your character's meaning.
     The conversation takes place in {language}.\n\n
     {conversation_summary}

--- a/config.ini
+++ b/config.ini
@@ -108,6 +108,7 @@ max_response_sentences = 999
 ;   Your alternative api_base must support openai's python streaming protocol.
 ;   Examples: 
 ;       http://127.0.0.1:5001/v1 for textgenwebui using the default openai extension
+;       http://127.0.0.1:5001/v1 for koboldcpp (after version 1.46 of koboldcpp which supports the openai API)
 ;       http://localhost:8080/v1 using the default endpoint for Local.ai
 ;       https://openrouter.ai/api/v1 for openrouter
 ;   Ensure that you have the correct secret key set in GPT_SECRET_KEY.txt for the service you are using

--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ try:
         character = character_manager.Character(character_info, language_info['language'], is_generic_npc)
         # if the NPC is from a mod, create the NPC's voice folder and exit Mantella
         chat_manager.setup_voiceline_save_location(character_info['in_game_voice_model'])
-        context = character.set_context(config.prompt, location, in_game_time)
+        context = character.set_context(config.system_message, config.prompt, location, in_game_time)
 
         tokens_available = token_limit - chat_response.num_tokens_from_messages(context, model=config.llm)
         
@@ -113,7 +113,7 @@ try:
 
             # if the conversation is becoming too long, save the conversation to memory and reload
             current_conversation_limit_pct = 0.45
-            if chat_response.num_tokens_from_messages(messages[1:], model=config.llm) > (round(tokens_available*current_conversation_limit_pct,0)):
+            if chat_response.num_tokens_from_messages(messages[2:], model=config.llm) > (round(tokens_available*current_conversation_limit_pct,0)):
                 conversation_summary_file, context, messages = game_state_manager.reload_conversation(config, encoding, synthesizer, chat_manager, messages, character, tokens_available, location, in_game_time)
                 # continue conversation
                 messages = asyncio.run(get_response(f"{character.info['name']}?", context, synthesizer, character.info))

--- a/src/character_manager.py
+++ b/src/character_manager.py
@@ -40,7 +40,7 @@ class Character:
         return conversation_summary_file
     
 
-    def set_context(self, prompt, location, in_game_time):
+    def set_context(self, system_message, prompt, location, in_game_time):
         # if conversation history exists, load it
         if os.path.exists(self.conversation_history_file):
             with open(self.conversation_history_file, 'r') as f:
@@ -53,14 +53,14 @@ class Character:
             with open(self.conversation_summary_file, 'r') as f:
                 previous_conversation_summaries = f.read()
 
-            context = self.create_context(prompt, location, in_game_time, len(previous_conversations), previous_conversation_summaries)
+            context = self.create_context(system_message, prompt, location, in_game_time, len(previous_conversations), previous_conversation_summaries)
         else:
-            context = self.create_context(prompt, location, in_game_time)
+            context = self.create_context(system_message, prompt, location, in_game_time)
 
         return context
     
 
-    def create_context(self, prompt, location='Skyrim', time='12', trust_level=0, conversation_summary=''):
+    def create_context(self, system_message, prompt, location='Skyrim', time='12', trust_level=0, conversation_summary=''):
         if trust_level < 1:
             trust = 'a stranger'
         elif trust_level < 10:
@@ -74,6 +74,17 @@ class Character:
 
         time_group = utils.get_time_group(time)
 
+        formatted_system_message = system_message.format(
+            name=self.name, 
+            bio=self.bio, 
+            trust=trust, 
+            location=location, 
+            time=time, 
+            time_group=time_group, 
+            language=self.language, 
+            conversation_summary=conversation_summary
+        )
+        
         character_desc = prompt.format(
             name=self.name, 
             bio=self.bio, 
@@ -85,8 +96,10 @@ class Character:
             conversation_summary=conversation_summary
         )
         
+        logging.info(formatted_system_message)
         logging.info(character_desc)
-        context = [{"role": "system", "content": character_desc}]
+        
+        context = [{"role": "system", "content": formatted_system_message}, {"role": "user", "content": character_desc}]
         return context
         
 

--- a/src/character_manager.py
+++ b/src/character_manager.py
@@ -117,7 +117,7 @@ class Character:
                 conversation_history = json.load(f)
 
             # add new conversation to conversation history
-            conversation_history.append(messages[1:]) # append everything except the initial system prompt
+            conversation_history.append(messages[2:]) # append everything except the initial system prompt
         # if this is the first conversation
         else:
             directory = os.path.dirname(self.conversation_history_file)

--- a/src/chat_response.py
+++ b/src/chat_response.py
@@ -13,7 +13,7 @@ def chatgpt_api(input_text, messages, llm):
         logging.info('Getting ChatGPT response...')
         try:
             chat_completion = openai.ChatCompletion.create(
-                model=llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},
+                model=llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'}, max_tokens=300
             )
         except openai.error.RateLimitError:
             logging.warning('Could not connect to ChatGPT API, retrying in 5 seconds...')

--- a/src/config_editor.py
+++ b/src/config_editor.py
@@ -73,7 +73,7 @@ class MantellaConfigEditor:
                 entry = ttk.Entry(tab, width=90)
                 entry.insert(0, self.config.get(section, option))
             # prompt option is a multiline string
-            elif (option == 'prompt'):
+            elif (option == 'prompt' or option == 'system_message'):
                 entry = Text(tab)
                 entry.insert(1.0, self.config.get(section, option))
             else:
@@ -118,7 +118,7 @@ class MantellaConfigEditor:
             options = self.config.options(section)
             for option in options:
                 # prompt option is a multiline string
-                if (option == 'prompt'):
+                if (option == 'prompt') or (option == 'system_message'):
                     self.config.set(section, option, self.widget_values[f"{section}.{option}"].get(1.0, 'end-1c'))
                 else:
                     self.config.set(section, option, self.widget_values[f"{section}.{option}"].get())

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -82,6 +82,7 @@ https://github.com/art-from-the-machine/Mantella#issues-qa
             self.debug_exit_on_first_exchange = config['Debugging']['exit_on_first_exchange']
             self.add_voicelines_to_all_voice_folders = config['Debugging']['add_voicelines_to_all_voice_folders']
 
+            self.system_message = config['Prompt']['system_message']
             self.prompt = config['Prompt']['prompt']
             pass
         except Exception as e:

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -349,10 +349,10 @@ class GameStateManager:
         # if a new conversation summary file was created, load this latest file
         conversation_summary_file = character.get_latest_conversation_summary_file_path()
         # reload context
-        context = character.set_context(config.prompt, location, in_game_time)
+        context = character.set_context(config.system_message, config.prompt, location, in_game_time)
 
         # add previous few back and forths from last conversation
-        messages_wo_system_prompt = messages[1:]
+        messages_wo_system_prompt = messages[2:]
         messages_last_entries = messages_wo_system_prompt[-8:]
         context.extend(messages_last_entries)
 

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -187,7 +187,7 @@ class ChatManager:
         while True:
             try:
                 start_time = time.time()
-                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},stream=True,):
+                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},stream=True,stop=['#']):
                     content = chunk["choices"][0].get("delta", {}).get("content")
                     if content is not None:
                         sentence += content


### PR DESCRIPTION
-This PR is for **testing and further input**

-It divides the original system message from the prompt into two parts, the true "system message" (e.g. "role":"system") which is intended to be shorter and more high-level, and the prompt, which would be transmitted as "role":"user" through openai.  Users could decide how much and what to put in the true system message vs. the rest of the prompt in case that has an impact on openai or local llm responses.

-_Also changes some of the text of the default prompt_ for testing / consideration.

-Unclear whether this will be better or worse, so needs a lot more testing and feedback before merging.

-**Needs more testing** to see if the additional functions break anything as well before merging.

-Basic reason for the PR is to evaluate a potential approach to address some user concerns that AI does not respond as much in character as expected even with the known constraints of Openai.  Possibly by shortening the system message focusing on certain character traits and then using the first user prompt message to convey the rest of the information it might keep the AI more "on character" and "on track." Not sure.