### PR TITLE
add customizable openai API llm parameters

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -111,6 +111,7 @@ max_response_sentences = 999
 ;       http://127.0.0.1:5001/v1 for koboldcpp (after version 1.46 of koboldcpp which supports the openai API)
 ;       http://localhost:8080/v1 using the default endpoint for Local.ai
 ;       https://openrouter.ai/api/v1 for openrouter
+;       http://localhost:5001/v1 for using koboldcpp locally or the url you obtain from the koboldcpp google colab notebook with /v1 added at the end.
 ;   Ensure that you have the correct secret key set in GPT_SECRET_KEY.txt for the service you are using
 ;   Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running mantella
 ;   Leave this value as none to use the normal openai chat gpt models.
@@ -122,6 +123,18 @@ alternative_openai_api_base = none
 ;   Keep in mind that if this number is greater than the actual token count of the model, then Mantella will crash if a given conversation exceeds the model's token limit
 ;   Default: 4096
 custom_token_count = 4096
+
+; The following parameters are as described in the OpenAI API documentation found here: https://platform.openai.com/docs/api-reference/chat/create. Read the documentation before changing these.
+; temperature is a floating point number between 0 and 2.
+temperature = 1
+; top_p is a floating point number between 0 and 1.
+top_p = 1
+; stop is a list of up to FOUR strings, if you want more than one stopping string use this format: string1,string2,string3,string4
+stop = #
+; frequency_penalty is a floating point number between -2.0 and 2.0
+frequency_penalty = 0
+; max_tokens is an integer.
+max_tokens = 250
 
 
 [Speech]

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -66,6 +66,19 @@ https://github.com/art-from-the-machine/Mantella#issues-qa
             self.llm = config['LanguageModel']['model']
             self.alternative_openai_api_base = config['LanguageModel']['alternative_openai_api_base']
             self.custom_token_count = config['LanguageModel']['custom_token_count']
+            self.temperature = float(config['LanguageModel']['temperature'])
+            self.top_p = float(config['LanguageModel']['top_p'])
+
+            stop_value = config['LanguageModel']['stop']
+            if ',' in stop_value:
+                # If there are commas in the stop value, split the string by commas and store the values in a list
+                self.stop = stop_value.split(',')
+            else:
+                # If there are no commas, put the single value into a list
+                self.stop = [stop_value]
+
+            self.frequency_penalty = float(config['LanguageModel']['frequency_penalty'])
+            self.max_tokens = int(config['LanguageModel']['max_tokens'])
 
             self.xvasynth_process_device = config['Speech']['tts_process_device']
             self.pace = float(config['Speech']['pace'])

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -18,6 +18,11 @@ class ChatManager:
         self.max_response_sentences = config.max_response_sentences
         self.llm = config.llm
         self.alternative_openai_api_base = config.alternative_openai_api_base
+        self.temperature = config.temperature
+        self.top_p = config.top_p
+        self.stop = config.stop
+        self.frequency_penalty = config.frequency_penalty
+        self.max_tokens = config.max_tokens
         self.language = config.language
         self.encoding = encoding
         self.add_voicelines_to_all_voice_folders = config.add_voicelines_to_all_voice_folders
@@ -187,7 +192,7 @@ class ChatManager:
         while True:
             try:
                 start_time = time.time()
-                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},stream=True,stop=['#']):
+                async for chunk in await openai.ChatCompletion.acreate(model=self.llm, messages=messages, headers={"HTTP-Referer": 'https://github.com/art-from-the-machine/Mantella', "X-Title": 'mantella'},stream=True,stop=self.stop,temperature=self.temperature,top_p=self.top_p,frequency_penalty=self.frequency_penalty, max_tokens=self.max_tokens):
                     content = chunk["choices"][0].get("delta", {}).get("content")
                     if content is not None:
                         sentence += content


### PR DESCRIPTION
-based on user requests, expose standard openai parameters for experimentation

-do not use parameters for chat response since that is a single-shot and things like temperature changes or length could have a negative impact for summaries

-expose temperature, top_p, frequency_penalty, max_tokens, and stop parameters, and set them all to the openai defaults except for max_tokens since default max tokens for openai is infinite.  250 should be a sufficient balance in combination with max_sentences.

-as per openai api docs, stop can be a single string or list of strings.  Tested with both.

-tested with koboldcpp (via google colab), openrouter and openai and had no errors.

-may want to add to the readme that if these are set to parameters openai does not expect chatgpt errors could occur at runtime.