### PR TITLE
support whispercpp server as alternative to faster-whisper

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -69,30 +69,6 @@ follow_npc_response = Follow
 ;   Options: 0, 1
 microphone_enabled = 1
 
-; model_size
-; 	The size of the Whisper model used. Some languages require larger models. The base.en model works well enough for English
-; 	See here for a comparison of languages and their Whisper performance: 
-; 	https://github.com/openai/whisper#available-models-and-languages
-; 	Options: tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v1, or large-v2
-model_size = base
-
-; language
-;   The user's spoken language
-;   The two letter ISO 639-1 language code
-;   default = The one set in [Language]language above
-stt_language = default
-
-; translate
-;   Translate the transcribed speech to English if supported by the Speech-To-Text engine
-;   STTs that support this function: Whisper
-;   Options: 0, 1
-stt_translate = 0
-
-; process_device
-;   Whether to run Whisper on your CPU or NVIDIA GPU (with CUDA installed)
-; 	Options: cpu, cuda
-process_device = cpu
-
 ; audio_threshold
 ; 	Controls how much background noise is filtered out
 ; 	If the mic is not picking up speech, try lowering this value
@@ -116,18 +92,42 @@ pause_threshold = 0.5
 ;   Recommended: 30
 listen_timeout = 30
 
+; model_size
+; 	The size of the Whisper model used. Some languages require larger models. The base.en model works well enough for English
+; 	See here for a comparison of languages and their Whisper performance: 
+; 	https://github.com/openai/whisper#available-models-and-languages
+; 	Options: tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v1, or large-v2
+model_size = base
+
+; language
+;   The user's spoken language
+;   The two letter ISO 639-1 language code
+;   default = The one set in [Language]language above
+stt_language = default
+
+; translate
+;   Translate the transcribed speech to English if supported by the Speech-To-Text engine (only impacts faster_whisper option, no impact on whispercpp, which is controlled by your server)
+;   STTs that support this function: Whisper (faster_whisper)
+;   Options: 0, 1
+stt_translate = 0
+
+; process_device
+;   Whether to run Whisper on your CPU or NVIDIA GPU (with CUDA installed) (only impacts faster_whisper option, no impact on whispercpp, which is controlled by your server)
+; 	Options: cpu, cuda
+process_device = cpu
+
 ; whisper_type
 ;   Advanced users only.  Allows using whispercpp (https://github.com/ggerganov/whisper.cpp) in server mode instead of default faster_whisper.
 ;   The main benefits would be to reduce vram usage when using larger whisper models, to enable use of distil-whisper models,
 ;   To share a whisper speech to text service between AI mods like mantella and herika, or run the whispercpp server in a cloud service.
 ;   In whispercpp server mode, the server settings, not the ones above, will control the model you use and cpu vs. gpu usage.  
-;   You are expected to "bring your own server" and have it running while running Mantella.
+;   You are expected to "bring your own server" and have whispercpp running while running Mantella.
 ;   If the default works for you, DO NOT change this variable.  To change to whispercpp server mode instead, enter whispercpp.
 ;   default: faster_whisper
 whisper_type = faster_whisper
 
 ; whisper_url
-;   Advanced users only.  Allows entering a server url.  If you use whispercpp above in whisper_type, the enter the whispercpp server URL here.
+;   Advanced users only.  Allows entering a server url.  If you use whispercpp above in whisper_type, then enter the whispercpp server URL here.
 ;   Example: http://127.0.0.1:8080/inference
 whisper_url = http://127.0.0.1:8080/inference
 

--- a/config.ini
+++ b/config.ini
@@ -116,6 +116,20 @@ pause_threshold = 0.5
 ;   Recommended: 30
 listen_timeout = 30
 
+; whisper_type
+;   Advanced users only.  Allows using whispercpp (https://github.com/ggerganov/whisper.cpp) in server mode instead of default faster_whisper.
+;   The main benefits would be to reduce vram usage when using larger whisper models, to enable use of distil-whisper models,
+;   To share a whisper speech to text service between AI mods like mantella and herika, or run the whispercpp server in a cloud service.
+;   In whispercpp server mode, the server settings, not the ones above, will control the model you use and cpu vs. gpu usage.  
+;   You are expected to "bring your own server" and have it running while running Mantella.
+;   If the default works for you, DO NOT change this variable.  To change to whispercpp server mode instead, enter whispercpp.
+;   default: faster_whisper
+whisper_type = faster_whisper
+
+; whisper_url
+;   Advanced users only.  Allows entering a server url.  If you use whispercpp above in whisper_type, the enter the whispercpp server URL here.
+;   Example: http://127.0.0.1:8080/inference
+whisper_url = http://127.0.0.1:8080/inference
 
 [Hotkey]
 ; hotkey

--- a/config.ini
+++ b/config.ini
@@ -127,8 +127,9 @@ process_device = cpu
 whisper_type = faster_whisper
 
 ; whisper_url
-;   Advanced users only.  Allows entering a server url.  If you use whispercpp above in whisper_type, then enter the whispercpp server URL here.
-;   Example: http://127.0.0.1:8080/inference
+;   Advanced users only.  Allows entering a openai-compatible server url.  If you use whispercpp above in whisper_type, then enter the whispercpp server URL here.
+;   Note that if you are also using the Herika mod, the default 8080 port used by whispercpp server may conflict with Herika. You can change the port to, e.g., 8070 instead to avoid the conflict.
+;   Examples: http://127.0.0.1:8080/inference (default)  /   http://127.0.0.1:8070/inference (if you use the optional --port 8070 comand line argument)
 whisper_url = http://127.0.0.1:8080/inference
 
 [Hotkey]

--- a/config.ini
+++ b/config.ini
@@ -96,7 +96,7 @@ listen_timeout = 30
 ; 	The size of the Whisper model used. Some languages require larger models. The base.en model works well enough for English
 ; 	See here for a comparison of languages and their Whisper performance: 
 ; 	https://github.com/openai/whisper#available-models-and-languages
-; 	Options: tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v1, or large-v2
+; 	Options: tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v1, large-v2, or whisper-1 (if using OpenAI API, see whisper_type setting below)
 model_size = base
 
 ; language
@@ -117,19 +117,22 @@ stt_translate = 0
 process_device = cpu
 
 ; whisper_type
-;   Advanced users only.  Allows using whispercpp (https://github.com/ggerganov/whisper.cpp) in server mode instead of default faster_whisper.
+;   Advanced users only. Allows using whispercpp (https://github.com/ggerganov/whisper.cpp) in server mode instead of default faster_whisper.
+;   Alternatively, can be used to run Whisper via the OpenAI API.
 ;   The main benefits would be to reduce vram usage when using larger whisper models, to enable use of distil-whisper models,
-;   To share a whisper speech to text service between AI mods like mantella and herika, or run the whispercpp server in a cloud service.
+;   to share a whisper speech to text service between AI mods like Mantella and Herika, or run the whispercpp server in a cloud service.
 ;   In whispercpp server mode, the server settings, not the ones above, will control the model you use and cpu vs. gpu usage.  
 ;   You are expected to "bring your own server" and have whispercpp running while running Mantella.
-;   If the default works for you, DO NOT change this variable.  To change to whispercpp server mode instead, enter whispercpp.
+;   If the default works for you, DO NOT change this variable. 
+;   To change to whispercpp server mode / OpenAI API instead, enter whispercpp. 
+;   Additionally, if using the OpenAI API, ensure your GPT_SECRET_KEY.txt is an OpenAI key, whisper_url is "https://api.openai.com/v1/audio/transcriptions" below, and model_size is "whisper-1" above
 ;   default: faster_whisper
 whisper_type = faster_whisper
 
 ; whisper_url
-;   Advanced users only.  Allows entering a openai-compatible server url.  If you use whispercpp above in whisper_type, then enter the whispercpp server URL here.
+;   Advanced users only. Allows entering a openai-compatible server url. If you use whispercpp above in whisper_type, then enter the whispercpp server URL here.
 ;   Note that if you are also using the Herika mod, the default 8080 port used by whispercpp server may conflict with Herika. You can change the port to, e.g., 8070 instead to avoid the conflict.
-;   Examples: http://127.0.0.1:8080/inference (default)  /   http://127.0.0.1:8070/inference (if you use the optional --port 8070 comand line argument)
+;   Examples: http://127.0.0.1:8080/inference (default) / http://127.0.0.1:8070/inference (if you use the optional --port 8070 comand line argument), https://api.openai.com/v1/audio/transcriptions (if using OpenAI API)
 whisper_url = http://127.0.0.1:8080/inference
 
 [Hotkey]

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -68,6 +68,8 @@ https://github.com/art-from-the-machine/Mantella#issues-qa
             self.audio_threshold = config['Microphone']['audio_threshold']
             self.pause_threshold = float(config['Microphone']['pause_threshold'])
             self.listen_timeout = int(config['Microphone']['listen_timeout'])
+            self.whisper_type = config['Microphone']['whisper_type']
+            self.whisper_url = config['Microphone']['whisper_url']
 
             self.hotkey = config['Hotkey']['hotkey']
             self.textbox_timer = config['Hotkey']['textbox_timer']

--- a/src/stt.py
+++ b/src/stt.py
@@ -134,7 +134,7 @@ class Transcriber:
 
         audio_file = 'player_recording.wav'
         with open(audio_file, 'wb') as file:
-            file.write(audio.get_wav_data())
+            file.write(audio.get_wav_data(convert_rate=16000))
         
         transcript = whisper_transcribe(audio_file)
         logging.info(transcript)

--- a/src/stt.py
+++ b/src/stt.py
@@ -4,6 +4,7 @@ import logging
 import src.utils as utils
 import requests
 import json
+import openai
 
 class Transcriber:
     def __init__(self, game_state_manager, config):
@@ -117,8 +118,10 @@ class Transcriber:
             # this code queries the whispercpp server set by the user to obtain the response
             else:
                 url = self.whisper_url
+                headers = {"Authorization": f"Bearer {openai.api_key}",}
+                data = {'model': self.model}
                 files = {'file': open(audio, 'rb')}
-                response = requests.post(url, files=files)
+                response = requests.post(url, headers=headers, files=files, data=data)
                 response_data = json.loads(response.text)
                 if 'text' in response_data:
                     return response_data['text'].strip()

--- a/src/stt.py
+++ b/src/stt.py
@@ -115,10 +115,13 @@ class Transcriber:
                 result_text = ' '.join(segment.text for segment in segments)
 
                 return result_text
-            # this code queries the whispercpp server set by the user to obtain the response
+            # this code queries the whispercpp server set by the user to obtain the response, this format also allows use of official openai whisper API
             else:
                 url = self.whisper_url
-                headers = {"Authorization": f"Bearer {openai.api_key}",}
+                if 'openai' in url:
+                    headers = {"Authorization": f"Bearer {openai.api_key}",}
+                else:
+                    headers = {"Authorization": "Bearer apikey",}
                 data = {'model': self.model}
                 files = {'file': open(audio, 'rb')}
                 response = requests.post(url, headers=headers, files=files, data=data)


### PR DESCRIPTION
-Credit to Elbios from Herika discord for a ton of help on this.

-This commit allows advanced users to run a whispercpp server and query that instead of using faster_whisper if they want

-Main benefits are reduced VRAM requirements depending on model, greater control of server parameters, use of distil_whisper model and benefits of any further improvments to whispercpp

-Still default to faster_whisper as "hands off" method for whisper for other uses.

-In theory this PR could be expanded to add the headers and model field ("model":"whisper-1") necessary for openai's online whisper by importing openai, using authentication through openai.api_key, but for some reason when I tried to add those, the whispercpp server would not work so leaving out for now.

-Another benefit is that when herika adds whispercpp server support, users using both mods will not have duplicated vram requirements if they want to run both mods locally on the same PC.

-Would appreciate some testing by others.  To test:

(1) download whispercpp binary here: https://github.com/ggerganov/whisper.cpp/suites/18468057202/artifacts/1071315923 (cpu) or https://github.com/ggerganov/whisper.cpp/suites/18468057202/artifacts/1071315933 (cuda)

(2) download the base whisper ggml model from here: https://huggingface.co/ggerganov/whisper.cpp/blob/main/ggml-base.bin

(3) put the base model into the whispercpp directory you downloaded

(4) open command line, cd to the whispercpp directory and run: server.exe -m ggml-base.bin.  You should see the model load and it say that a server is running.  

(5) In the config.ini change whisper_type to whispercpp and run mantella as usual