### PR TITLE
Mantella spell text files refactoring

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -161,7 +161,7 @@ model = gpt-3.5-turbo-1106
 max_response_sentences = 999
 
 ; wait_time_buffer
-;   Time to wait before generating the next voiceline
+;   Time to wait (in seconds) before generating the next voiceline
 ;   Mantella waits for the duration of a given voiceline's .wav file + an extra buffer to account for processing overhead within Skyrim
 ;   If you are noticing that some voicelines are not being said in-game, try increasing this buffer
 ;   Default: 1.0

--- a/config.ini
+++ b/config.ini
@@ -164,8 +164,8 @@ max_response_sentences = 999
 ;   Time to wait before generating the next voiceline
 ;   Mantella waits for the duration of a given voiceline's .wav file + an extra buffer to account for processing overhead within Skyrim
 ;   If you are noticing that some voicelines are not being said in-game, try increasing this buffer
-;   Default: 1.3
-wait_time_buffer = 1.3
+;   Default: 1.0
+wait_time_buffer = 1.0
 
 ; alternative_openai_api_base
 ;   If you are using openai's services, leave this alone, otherwise you can change this variable to another base_api that uses openai's api

--- a/main.py
+++ b/main.py
@@ -166,7 +166,7 @@ try:
 
 except Exception as e:
     try:
-        game_state_manager.write_game_info('_mantella_error_check', 'True')
+        game_state_manager.write_game_info('_mantella_status', 'Error with Mantella.exe. Please check MantellaSoftware/logging.log')
     except:
         None
 

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -56,7 +56,7 @@ class GameStateManager:
 
         self.write_game_info('_mantella_in_game_events', '')
 
-        self.write_game_info('_mantella_error_check', 'False')
+        self.write_game_info('_mantella_status', 'False')
 
         self.write_game_info('_mantella_actor_is_enemy', 'False')
 

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -84,7 +84,6 @@ class ChatManager:
         """Save voicelines and subtitles to the correct game folders"""
 
         audio_file, subtitle = queue_output
-        self.game_state_manager.write_game_info('_mantella_subtitle', subtitle.strip())
         if self.add_voicelines_to_all_voice_folders == '1':
             for sub_folder in os.scandir(self.mod_folder):
                 if sub_folder.is_dir():
@@ -96,10 +95,10 @@ class ChatManager:
 
         logging.info(f"{self.active_character.name} should speak")
         if self.character_num == 0:
-            self.game_state_manager.write_game_info('_mantella_say_line', 'True')
+            self.game_state_manager.write_game_info('_mantella_say_line', subtitle.strip())
         else:
             say_line_file = '_mantella_say_line_'+str(self.character_num+1)
-            self.game_state_manager.write_game_info(say_line_file, 'True')
+            self.game_state_manager.write_game_info(say_line_file, subtitle.strip())
 
     @utils.time_it
     def remove_files_from_voice_folders(self):

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -73,7 +73,7 @@ class ChatManager:
                 if os.path.isfile(source_file_path):
                     shutil.copy(source_file_path, in_game_voice_folder_path)
 
-            self.game_state_manager.write_game_info('_mantella_error_check', 'True')
+            self.game_state_manager.write_game_info('_mantella_status', 'Error with Mantella.exe. Please check MantellaSoftware/logging.log')
             logging.warn("Unknown NPC detected. This NPC will be able to speak once you restart Skyrim. To learn how to add memory, a background, and a voice model of your choosing to this NPC, see here: https://github.com/art-from-the-machine/Mantella#adding-modded-npcs")
             input('\nPress any key to exit...')
             sys.exit(0)

--- a/src/stt.py
+++ b/src/stt.py
@@ -85,7 +85,7 @@ class Transcriber:
         Recognize input from mic and return transcript if activation tag (assistant name) exist
         """
         while True:
-            self.game_state_manager.write_game_info('_mantella_listening', 'True')
+            self.game_state_manager.write_game_info('_mantella_status', 'Listening...')
             logging.info('Listening...')
             transcript = self._recognize_speech_from_mic()
             transcript_cleaned = utils.clean_text(transcript)
@@ -98,7 +98,7 @@ class Transcriber:
             if transcript_cleaned in ['', 'thank you', 'thank you for watching', 'thanks for watching', 'the transcript is from the', 'the', 'thank you very much']:
                 continue
 
-            self.game_state_manager.write_game_info('_mantella_thinking', 'True')
+            self.game_state_manager.write_game_info('_mantella_status', 'Thinking...')
             return transcript
     
 


### PR DESCRIPTION
Streamlined the Mantella spell conversation loop by:
1. Merging the Listening... / Thinking... / Error statuses into one file (`_mantella_status.txt`)
2. Passing subtitle data as part of the `_mantella_say_line.txt` check to avoid the redundancy of having both a `_mantella_say_line.txt` and `_mantella_subtitle.txt`