### PR TITLE
Implement user configurable option for whether player talks first or npc

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -62,6 +62,12 @@ forgiven_npc_response = Forgiven
 ;   This should match what is stated in the prompt at the bottom of this config file
 follow_npc_response = Follow
 
+;player_speaks_first
+;   This variable controls whether the NPC speaks to the player first (in response to a "hello" prompt automatically sent by Mantella)
+;   Or whether the player gets a chance to talk or type first before the NPC says anything
+;   0 = default, NPC speaks first to player
+;   1 = option, Player inputs text or speaks to NPC first
+player_speaks_first = 0
 
 [Microphone]
 ; microphone_enabled

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -53,6 +53,7 @@ https://github.com/art-from-the-machine/Mantella#issues-qa
             self.offended_npc_response = config['Language']['offended_npc_response']
             self.forgiven_npc_response = config['Language']['forgiven_npc_response']
             self.follow_npc_response = config['Language']['follow_npc_response']
+            self.player_speaks_first = bool(int(config['Language']['player_speaks_first']))
 
             self.game_path = config['Paths']['skyrim_folder']
             self.xvasynth_path = config['Paths']['xvasynth_folder']


### PR DESCRIPTION
-provides option in config file for player to be the first one to talk instead of NPC talking first.  So when activating mantella on an NPC, goes to "listening" mode immediately instead of using the "hello" prompt to the NPC if the option is activated.  Default is left as off to not disturb normal mantella behavior players have gotten used to.

-Needs testing with typing / hotkey / giamel dialogue menu version of mantella before merging

-tested with option on (player_speaks_first = 1) and off (player_speaks_first = 0) in VR with speech and all was fine.