### PR TITLE
MCM setting changes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -66,6 +66,7 @@ follow_npc_response = Follow
 [Microphone]
 ; microphone_enabled
 ;   Whether to use microphone input (1) or text input (0)
+;   NOTE: This setting is overwritten by the MCM menu setting if that setting has been configured
 ;   Options: 0, 1
 microphone_enabled = 1
 
@@ -137,16 +138,10 @@ whisper_url = http://127.0.0.1:8080/inference
 
 [Hotkey]
 ; hotkey
-;   The hotkey used to start conversations / bring up the textbox
-;   If you would like to use textbox input, please set microphone_enabled = 0 above
-;   Please find the number value (Dec) for your desired hotkey here: https://www.creationkit.com/index.php?title=Input_Script#DXScanCodes
-;   Default: 35 (H)
-hotkey = 35
+;   The hotkey can be configured in Mantella's MCM menu
 
 ; textbox_timer
-;   How long (in seconds) Mantella should wait before the input textbox automatically pops up
-;   Default = 180
-textbox_timer = 180
+;   The textbox timer can be configured in Mantella's MCM menu
 
 
 [LanguageModel]

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import src.chat_response as chat_response
 import logging
 import src.utils as utils
 import sys
+import os
 import asyncio
 import src.output_manager as output_manager
 import src.game_manager as game_manager
@@ -36,6 +37,13 @@ try:
     mantella_version = '0.10'
     logging.info(f'\nMantella v{mantella_version}')
 
+    # Check if the mic setting has been configured in MCM
+    # If it has, use this instead of the config.ini setting, otherwise take the config.ini value
+    if os.path.exists(f'{config.game_path}/_mantella_microphone_enabled.txt'):
+        with open(f'{config.game_path}/_mantella_microphone_enabled.txt', 'r', encoding='utf-8') as f:
+            mcm_mic_enabled = f.readline().strip()
+        config.mic_enabled = '1' if mcm_mic_enabled == 'TRUE' else '0'
+
     game_state_manager = game_manager.GameStateManager(config.game_path)
     chat_manager = output_manager.ChatManager(game_state_manager, config, encoding)
     transcriber = stt.Transcriber(game_state_manager, config)
@@ -46,10 +54,6 @@ try:
         character_name, character_id, location, in_game_time = game_state_manager.reset_game_info()
 
         characters = characters_manager.Characters()
-
-        # add hotkey info
-        game_state_manager.write_game_info('_mantella_conversation_hotkey', config.hotkey)
-        game_state_manager.write_game_info('_mantella_response_timer', config.textbox_timer)
 
         logging.info('\nConversations not starting when you select an NPC? See here:\nhttps://github.com/art-from-the-machine/Mantella#issues-qa')
         logging.info('\nWaiting for player to select an NPC...')


### PR DESCRIPTION
Removed hotkey and textbox timer settings from config.ini as they are now found in the MCM menu. Added check to see if the microphone enabled setting has been edited in the MCM menu, and if it has, use this value instead of config.ini. The microphone enabled setting has not been entirely removed from config.ini to still allow for local (ie no opening Skyrim) debugging.