### PR TITLE
mercury7 radiant dialogue and multi NPC merge

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -324,10 +324,10 @@ prompt = You are {name}, and you live in Skyrim. This is your background:\n\n{bi
     The conversation takes place in {language}.\n\n
     {conversation_summary}
 
-multi_npc_prompt = The following is a conversation in {location} in Skyrim between the player, {names}. Here are their backgrounds: {bios} 
+multi_npc_prompt = The following is a conversation in {location} in Skyrim between {names_w_player}. Here are their backgrounds: {bios} 
     And here are their conversation histories: {conversation_summaries} 
     The time is {time} {time_group}. If you directly refer to the time, please state it as, for example, '10 in the evening' rather than '22:00'. 
-    You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening, how may I help you?'. 
-    Please use your own discretion to decide who should respond to the player (sometimes responding with all NPCs is suitable). 
+    You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'. 
+    Please use your own discretion to decide who should speak in a given situation (sometimes responding with all NPCs is suitable). 
     Remember, you can only respond as {names}. Ensure to use their full name when responding.
     The conversation takes place in {language}.

--- a/main.py
+++ b/main.py
@@ -12,13 +12,13 @@ import src.character_manager as character_manager
 import src.characters_manager as characters_manager
 import src.setup as setup
 
-async def get_response(input_text, messages, synthesizer, characters):
+async def get_response(input_text, messages, synthesizer, characters, radiant_dialogue):
     sentence_queue = asyncio.Queue()
     event = asyncio.Event()
     event.set()
 
     results = await asyncio.gather(
-        chat_manager.process_response(sentence_queue, input_text, messages, synthesizer, characters, event), 
+        chat_manager.process_response(sentence_queue, input_text, messages, synthesizer, characters, radiant_dialogue, event), 
         chat_manager.send_response(sentence_queue, event)
     )
     messages, _ = results
@@ -54,6 +54,7 @@ try:
         character_name, character_id, location, in_game_time = game_state_manager.reset_game_info()
 
         characters = characters_manager.Characters()
+        transcriber.call_count = 0 # reset radiant back and forth count
 
         logging.info('\nConversations not starting when you select an NPC? See here:\nhttps://github.com/art-from-the-machine/Mantella#issues-qa')
         logging.info('\nWaiting for player to select an NPC...')
@@ -73,20 +74,27 @@ try:
         game_state_manager.write_game_info('_mantella_character_selection', 'True')
         # if the NPC is from a mod, create the NPC's voice folder and exit Mantella
         chat_manager.setup_voiceline_save_location(character_info['in_game_voice_model'])
-        context = character.set_context(config.prompt, location, in_game_time, characters.active_characters, token_limit)
+
+        with open(f'{config.game_path}/_mantella_radiant_dialogue.txt', 'r', encoding='utf-8') as f:
+            radiant_dialogue = f.readline().strip().lower()
+            conversation_started_radiant = radiant_dialogue
+        
+        context = character.set_context(config.prompt, location, in_game_time, characters.active_characters, token_limit, radiant_dialogue)
 
         tokens_available = token_limit - chat_response.num_tokens_from_messages(context, model=config.llm)
         
-        # initiate conversation with character
-        try:
-            messages = asyncio.run(get_response(f"{language_info['hello']} {character.name}.", context, synthesizer, characters))
-        except tts.VoiceModelNotFound:
-            game_state_manager.write_game_info('_mantella_end_conversation', 'True')
-            logging.info('Restarting...')
-            # if debugging and character name not found, exit here to avoid endless loop
-            if (config.debug_mode == '1') & (config.debug_character_name != 'None'):
-                sys.exit(0)
-            continue
+        messages = context.copy()
+        if radiant_dialogue == "false":
+            # initiate conversation with character
+            try:
+                messages = asyncio.run(get_response(f"{language_info['hello']} {character.name}.", context, synthesizer, characters, radiant_dialogue))
+            except tts.VoiceModelNotFound:
+                game_state_manager.write_game_info('_mantella_end_conversation', 'True')
+                logging.info('Restarting...')
+                # if debugging and character name not found, exit here to avoid endless loop
+                if (config.debug_mode == '1') & (config.debug_character_name != 'None'):
+                    sys.exit(0)
+                continue
 
         # debugging variable
         say_goodbye = False
@@ -97,8 +105,12 @@ try:
                 conversation_ended = f.readline().strip()
 
             with open(f'{config.game_path}/_mantella_actor_count.txt', 'r', encoding='utf-8') as f:
-                num_characters_selected = int(f.readline().strip())
+                try:
+                    num_characters_selected = int(f.readline().strip())
+                except:
+                    logging.info('Failed to read _mantella_actor_count.txt')
 
+            # check if new character has been added to conversation
             if num_characters_selected > characters.active_character_count():
                 try:
                     # load character when data is available
@@ -124,49 +136,71 @@ try:
                 # if the NPC is from a mod, create the NPC's voice folder and exit Mantella
                 chat_manager.setup_voiceline_save_location(character_info['in_game_voice_model'])
 
-                # add greeting from newly added NPC to help the LLM understand that this NPC has joined the conversation
-                messages_wo_system_prompt[last_assistant_idx]['content'] += f"\n{character.name}: {language_info['hello']}."
+                # if not radiant dialogue format
+                if radiant_dialogue == "false":
+                    # add greeting from newly added NPC to help the LLM understand that this NPC has joined the conversation
+                    messages_wo_system_prompt[last_assistant_idx]['content'] += f"\n{character.name}: {language_info['hello']}."
                 
-                new_context = character.set_context(config.multi_npc_prompt, location, in_game_time, characters.active_characters, token_limit)
-                new_context.extend(messages_wo_system_prompt)
+                new_context = character.set_context(config.multi_npc_prompt, location, in_game_time, characters.active_characters, token_limit, radiant_dialogue)
+
+                # if not radiant dialogue format
+                if radiant_dialogue == "false":
+                    new_context.extend(messages_wo_system_prompt)
+                    new_context = character.set_context(config.multi_npc_prompt, location, in_game_time, characters.active_characters, token_limit, radiant_dialogue)
+
                 messages = new_context.copy()
                 game_state_manager.write_game_info('_mantella_character_selection', 'True')
+            
+            # if radiant dialogue, do not run the conversation until all NPCs are loaded (ie actor count > 1)
+            if (characters.active_character_count() > 1) or (radiant_dialogue == "false"):
+                # if the conversation was initially radiant but now the player is jumping in, reset the system prompt to include player
+                if (radiant_dialogue == "false") and (conversation_started_radiant == "true"):
+                    conversation_started_radiant = "false"
+                    messages_wo_system_prompt = messages[1:]
 
-            transcript_cleaned = ''
-            if conversation_ended.lower() != 'true':
-                transcribed_text, say_goodbye = transcriber.get_player_response(say_goodbye)
+                # check if radiant dialogue has switched to multi NPC
+                with open(f'{config.game_path}/_mantella_radiant_dialogue.txt', 'r', encoding='utf-8') as f:
+                    radiant_dialogue = f.readline().strip().lower()
+                
+                transcript_cleaned = ''
+                transcribed_text = None
+                if conversation_ended.lower() != 'true':
+                    transcribed_text, say_goodbye = transcriber.get_player_response(say_goodbye, radiant_dialogue)
 
-                game_state_manager.write_game_info('_mantella_player_input', transcribed_text)
+                    game_state_manager.write_game_info('_mantella_player_input', transcribed_text)
 
-                transcript_cleaned = utils.clean_text(transcribed_text)
+                    transcript_cleaned = utils.clean_text(transcribed_text)
 
-            # check if conversation has ended again after player input
-            with open(f'{config.game_path}/_mantella_end_conversation.txt', 'r', encoding='utf-8') as f:
-                conversation_ended = f.readline().strip()
+                    # if multi NPC conversation, add "Player:" to beginning of output to clarify to the LLM who is speaking
+                    if (characters.active_character_count() > 1) and (radiant_dialogue != "true"):
+                        transcribed_text = 'Player: ' + transcribed_text
+                    # add in-game events to player's response
+                    transcribed_text = game_state_manager.update_game_events(transcribed_text)
+                    logging.info(f"Text passed to NPC: {transcribed_text}")
 
-            # check if user is ending conversation
-            if (transcriber.activation_name_exists(transcript_cleaned, config.end_conversation_keyword.lower())) or (transcriber.activation_name_exists(transcript_cleaned, 'good bye')) or (conversation_ended.lower() == 'true'):
-                game_state_manager.end_conversation(conversation_ended, config, encoding, synthesizer, chat_manager, messages, characters.active_characters, tokens_available)
-                break
+                # check if conversation has ended again after player input
+                with open(f'{config.game_path}/_mantella_end_conversation.txt', 'r', encoding='utf-8') as f:
+                    conversation_ended = f.readline().strip()
 
-            # Let the player know that they were heard
-            #audio_file = synthesizer.synthesize(character.info['voice_model'], character.info['skyrim_voice_folder'], 'Beep boop. Let me think.')
-            #chat_manager.save_files_to_voice_folders([audio_file, 'Beep boop. Let me think.'])
+                # check if user is ending conversation
+                if (transcriber.activation_name_exists(transcript_cleaned, config.end_conversation_keyword.lower())) or (transcriber.activation_name_exists(transcript_cleaned, 'good bye')) or (conversation_ended.lower() == 'true'):
+                    game_state_manager.end_conversation(conversation_ended, config, encoding, synthesizer, chat_manager, messages, characters.active_characters, tokens_available)
+                    break
 
-            # add in-game events to player's response
-            transcribed_text = game_state_manager.update_game_events(transcribed_text)
-            logging.info(f"Text passed to NPC: {transcribed_text}")
+                # Let the player know that they were heard
+                #audio_file = synthesizer.synthesize(character.info['voice_model'], character.info['skyrim_voice_folder'], 'Beep boop. Let me think.')
+                #chat_manager.save_files_to_voice_folders([audio_file, 'Beep boop. Let me think.'])
 
-            # get character's response
-            if transcribed_text:
-                messages = asyncio.run(get_response(transcribed_text, messages, synthesizer, characters))
+                # get character's response
+                if transcribed_text:
+                    messages = asyncio.run(get_response(transcribed_text, messages, synthesizer, characters, radiant_dialogue))
 
-            # if the conversation is becoming too long, save the conversation to memory and reload
-            current_conversation_limit_pct = 0.45
-            if chat_response.num_tokens_from_messages(messages[1:], model=config.llm) > (round(tokens_available*current_conversation_limit_pct,0)):
-                conversation_summary_file, context, messages = game_state_manager.reload_conversation(config, encoding, synthesizer, chat_manager, messages, characters.active_characters, tokens_available, token_limit, location, in_game_time)
-                # continue conversation
-                messages = asyncio.run(get_response(f"{character.name}?", context, synthesizer, characters))
+                # if the conversation is becoming too long, save the conversation to memory and reload
+                current_conversation_limit_pct = 0.45
+                if chat_response.num_tokens_from_messages(messages[1:], model=config.llm) > (round(tokens_available*current_conversation_limit_pct,0)):
+                    conversation_summary_file, context, messages = game_state_manager.reload_conversation(config, encoding, synthesizer, chat_manager, messages, characters.active_characters, tokens_available, token_limit, location, in_game_time)
+                    # continue conversation
+                    messages = asyncio.run(get_response(f"{character.name}?", context, synthesizer, characters, radiant_dialogue))
 
 except Exception as e:
     try:

--- a/src/character_manager.py
+++ b/src/character_manager.py
@@ -43,7 +43,7 @@ class Character:
         return conversation_summary_file
     
 
-    def set_context(self, prompt, location, in_game_time, active_characters, token_limit):
+    def set_context(self, prompt, location, in_game_time, active_characters, token_limit, radiant_dialogue):
         # if conversation history exists, load it
         if os.path.exists(self.conversation_history_file):
             with open(self.conversation_history_file, 'r', encoding='utf-8') as f:
@@ -58,14 +58,14 @@ class Character:
 
             self.conversation_summary = previous_conversation_summaries
 
-            context = self.create_context(prompt, location, in_game_time, active_characters, token_limit, len(previous_conversations), previous_conversation_summaries)
+            context = self.create_context(prompt, location, in_game_time, active_characters, token_limit, radiant_dialogue, len(previous_conversations), previous_conversation_summaries)
         else:
-            context = self.create_context(prompt, location, in_game_time, active_characters, token_limit)
+            context = self.create_context(prompt, location, in_game_time, active_characters, token_limit, radiant_dialogue)
 
         return context
     
 
-    def create_context(self, prompt, location='Skyrim', time='12', active_characters=None, token_limit=4096, trust_level=0, conversation_summary='', prompt_limit_pct=0.75):
+    def create_context(self, prompt, location='Skyrim', time='12', active_characters=None, token_limit=4096, radiant_dialogue='false', trust_level=0, conversation_summary='', prompt_limit_pct=0.75):
         if self.relationship_rank == 0:
             if trust_level < 1:
                 trust = 'a stranger'
@@ -100,8 +100,14 @@ class Character:
                 conversation_summary=conversation_summary
             )
         else: # Multi NPC prompt
+            if radiant_dialogue == 'false': # don't mention player if radiant dialogue
+                keys_w_player = ['the player'] + keys
+            else:
+                keys_w_player = keys
+            
             # Join all but the last key with a comma, and add the last key with "and" in front
             character_names_list = ', '.join(keys[:-1]) + ' and ' + keys[-1]
+            character_names_list_w_player = ', '.join(keys_w_player[:-1]) + ' and ' + keys_w_player[-1]
 
             bio_descriptions = []
             for character_name, character in active_characters.items():
@@ -118,6 +124,7 @@ class Character:
             character_desc = prompt.format(
                 name=self.name, 
                 names=character_names_list,
+                names_w_player=character_names_list_w_player,
                 language=self.language,
                 location=location,
                 time=time,
@@ -132,6 +139,7 @@ class Character:
                 character_desc = prompt.format(
                     name=self.name, 
                     names=character_names_list,
+                    names_w_player=character_names_list_w_player,
                     language=self.language,
                     location=location,
                     time=time,
@@ -146,6 +154,7 @@ class Character:
                     character_desc = prompt.format(
                         name=self.name, 
                         names=character_names_list,
+                        names_w_player=character_names_list_w_player,
                         language=self.language,
                         location=location,
                         time=time,
@@ -214,7 +223,7 @@ class Character:
             logging.info(f'Token limit of conversation summaries reached ({len(encoding.encode(conversation_summaries))} / {summary_limit} tokens). Creating new summary file...')
             while True:
                 try:
-                    prompt = f"You are tasked with summarizing the conversation history between {self.name} (the assistant) and the player (the user), which took place in Skyrim. "\
+                    prompt = f"You are tasked with summarizing the conversation history between {self.name} (the assistant) and the player (the user) / other characters. These conversations take place in Skyrim. "\
                         f"Each paragraph represents a conversation at a new point in time. Please summarize these conversations into a single paragraph in {self.language}."
                     long_conversation_summary = self.summarize_conversation(conversation_summaries, llm, prompt)
                     break
@@ -241,7 +250,7 @@ class Character:
         if len(conversation) > 5:
             conversation = conversation[3:-2] # drop the context (0) hello (1,2) and "Goodbye." (-2, -1) lines
             if prompt == None:
-                prompt = f"You are tasked with summarizing the conversation between {self.name} (the assistant) and the player (the user), which took place in Skyrim. It is not necessary to comment on any mixups in communication such as mishearings. Text contained within asterisks state in-game events. Please summarize the conversation into a single paragraph in {self.language}."
+                prompt = f"You are tasked with summarizing the conversation between {self.name} (the assistant) and the player (the user) / other characters. These conversations take place in Skyrim. It is not necessary to comment on any mixups in communication such as mishearings. Text contained within asterisks state in-game events. Please summarize the conversation into a single paragraph in {self.language}."
             context = [{"role": "system", "content": prompt}]
             summary, _ = chat_response.chatgpt_api(f"{conversation}", context, llm)
 

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -71,8 +71,8 @@ https://github.com/art-from-the-machine/Mantella#issues-qa
             self.whisper_type = config['Microphone']['whisper_type']
             self.whisper_url = config['Microphone']['whisper_url']
 
-            self.hotkey = config['Hotkey']['hotkey']
-            self.textbox_timer = config['Hotkey']['textbox_timer']
+            #self.hotkey = config['Hotkey']['hotkey']
+            #self.textbox_timer = config['Hotkey']['textbox_timer']
 
             self.max_response_sentences = int(config['LanguageModel']['max_response_sentences'])
             self.llm = config['LanguageModel']['model']

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -80,6 +80,8 @@ class GameStateManager:
 
         self.write_game_info('_mantella_aggro', '')
 
+        self.write_game_info('_mantella_radiant_dialogue', 'False')
+
         return character_name, character_id, location, in_game_time
     
     

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -190,13 +190,14 @@ class ChatManager:
         return sentence
 
 
-    async def process_response(self, sentence_queue, input_text, messages, synthesizer, characters, event):
+    async def process_response(self, sentence_queue, input_text, messages, synthesizer, characters, radiant_dialogue, event):
         """Stream response from LLM one sentence at a time"""
 
         messages.append({"role": "user", "content": input_text})
         sentence = ''
         full_reply = ''
         num_sentences = 0
+        action_taken = False
         if self.alternative_openai_api_base == 'none':
             openai.aiosession.set(ClientSession()) # https://github.com/openai/openai-python#async-api
         while True:
@@ -220,39 +221,53 @@ class ChatManager:
                                 logging.info(f'Skipping voiceline that is too short: {sentence}')
                                 break
 
-                            logging.info(f"ChatGPT returned sentence took {time.time() - start_time} seconds to execute")
+                            logging.info(f"LLM returned sentence took {time.time() - start_time} seconds to execute")
 
-                            keyword_extraction = sentence.strip()[:-1] #.lower()
-                            if keyword_extraction in characters.active_characters:
-                                logging.info(f"Switched to {keyword_extraction}")
-                                self.active_character = characters.active_characters[keyword_extraction]
-                                # characters are mapped to say_line based on order of selection
-                                # taking the order of the dictionary to find which say_line to use, but it is bad practice to use dictionaries in this way
-                                self.character_num = list(characters.active_characters.keys()).index(keyword_extraction)
-                                full_reply += sentence
-                                sentence = ''
-                            elif keyword_extraction.lower() == self.offended_npc_response.lower():
-                                if self.experimental_features:
-                                    logging.info(f"The player offended the NPC")
-                                    self.game_state_manager.write_game_info('_mantella_aggro', '1')
-                                else:
-                                    logging.info(f"Experimental features disabled. Please set experimental_features = 1 in config.ini to enable the Offended feature")
-                                sentence = ''
-                            elif keyword_extraction.lower() == self.forgiven_npc_response.lower():
-                                if self.experimental_features:
-                                    logging.info(f"The player made up with the NPC")
-                                    self.game_state_manager.write_game_info('_mantella_aggro', '0')
-                                else:
-                                    logging.info(f"Experimental features disabled. Please set experimental_features = 1 in config.ini to enable the Forgiven feature")
-                                sentence = ''
-                            elif keyword_extraction.lower() == self.follow_npc_response.lower():
-                                if self.experimental_features:
-                                    logging.info(f"The NPC is willing to follow the player")
-                                    self.game_state_manager.write_game_info('_mantella_aggro', '2')
-                                else:
-                                    logging.info(f"Experimental features disabled. Please set experimental_features = 1 in config.ini to enable the Follow feature")
-                                sentence = ''
-                            else:
+                            if content_edit == ':':
+                                keyword_extraction = sentence.strip()[:-1] #.lower()
+                                # if LLM is switching character
+                                if (keyword_extraction in characters.active_characters):
+                                    #TODO: or (any(key.split(' ')[0] == keyword_extraction for key in characters.active_characters))
+                                    logging.info(f"Switched to {keyword_extraction}")
+                                    self.active_character = characters.active_characters[keyword_extraction]
+                                    # characters are mapped to say_line based on order of selection
+                                    # taking the order of the dictionary to find which say_line to use, but it is bad practice to use dictionaries in this way
+                                    self.character_num = list(characters.active_characters.keys()).index(keyword_extraction)
+                                    full_reply += sentence
+                                    sentence = ''
+                                    action_taken = True
+                                elif keyword_extraction == 'Player':
+                                    logging.info(f"Stopped LLM from speaking on behalf of the player")
+                                    break
+                                elif keyword_extraction.lower() == self.offended_npc_response.lower():
+                                    if self.experimental_features:
+                                        logging.info(f"The player offended the NPC")
+                                        self.game_state_manager.write_game_info('_mantella_aggro', '1')
+                                    else:
+                                        logging.info(f"Experimental features disabled. Please set experimental_features = 1 in config.ini to enable the Offended feature")
+                                    full_reply += sentence
+                                    sentence = ''
+                                    action_taken = True
+                                elif keyword_extraction.lower() == self.forgiven_npc_response.lower():
+                                    if self.experimental_features:
+                                        logging.info(f"The player made up with the NPC")
+                                        self.game_state_manager.write_game_info('_mantella_aggro', '0')
+                                    else:
+                                        logging.info(f"Experimental features disabled. Please set experimental_features = 1 in config.ini to enable the Forgiven feature")
+                                    full_reply += sentence
+                                    sentence = ''
+                                    action_taken = True
+                                elif keyword_extraction.lower() == self.follow_npc_response.lower():
+                                    if self.experimental_features:
+                                        logging.info(f"The NPC is willing to follow the player")
+                                        self.game_state_manager.write_game_info('_mantella_aggro', '2')
+                                    else:
+                                        logging.info(f"Experimental features disabled. Please set experimental_features = 1 in config.ini to enable the Follow feature")
+                                    full_reply += sentence
+                                    sentence = ''
+                                    action_taken = True
+
+                            if action_taken == False:
                                 # Generate the audio and return the audio file path
                                 try:
                                     audio_file = synthesizer.synthesize(self.active_character.voice_model, None, ' ' + sentence + ' ')
@@ -271,9 +286,16 @@ class ChatManager:
                                 # wait for the event to be set before generating the next line
                                 await event.wait()
 
-                            end_conversation = self.game_state_manager.load_data_when_available('_mantella_end_conversation', '')
-                            if (num_sentences >= self.max_response_sentences) or (end_conversation.lower() == 'true'):
-                                break
+                                end_conversation = self.game_state_manager.load_data_when_available('_mantella_end_conversation', '')
+                                radiant_dialogue_update = self.game_state_manager.load_data_when_available('_mantella_radiant_dialogue', '')
+                                # stop processing LLM response if:
+                                # max_response_sentences reached (and the conversation isn't radiant)
+                                # conversation has switched from radiant to multi NPC (this allows the player to "interrupt" radiant dialogue and include themselves in the conversation)
+                                # the conversation has ended
+                                if ((num_sentences >= self.max_response_sentences) and (radiant_dialogue == 'false')) or ((radiant_dialogue == 'true') and (radiant_dialogue_update.lower() == 'false')) or (end_conversation.lower() == 'true'):
+                                    break
+                            else:
+                                action_taken = False
                 if self.alternative_openai_api_base == 'none':
                     await openai.aiosession.get().close()
                 break

--- a/src/setup.py
+++ b/src/setup.py
@@ -113,7 +113,11 @@ def initialise(config_file, logging_file, secret_key_file, character_df_file, la
     #       this can lead to the token limit of the given model being overrun
     if config.alternative_openai_api_base != 'none':
         chosenmodel = 'gpt-3.5-turbo'
-    encoding = tiktoken.encoding_for_model(chosenmodel)
+    try:
+        encoding = tiktoken.encoding_for_model(chosenmodel)
+    except:
+        logging.error('Error loading model. If you are using an alternative to OpenAI, please find the setting `alternative_openai_api_base` in MantellaSoftware/config.ini and follow the instructions to change this setting')
+        raise
     token_limit = get_token_limit(config.llm, config.custom_token_count, is_local)
 
     if config.alternative_openai_api_base != 'none':

--- a/src/stt.py
+++ b/src/stt.py
@@ -28,6 +28,8 @@ class Transcriber:
         self.debug_exit_on_first_exchange = config.debug_exit_on_first_exchange
         self.end_conversation_keyword = config.end_conversation_keyword
 
+        self.call_count = 0
+
         if self.mic_enabled == '1':
             self.recognizer = sr.Recognizer()
             self.recognizer.pause_threshold = config.pause_threshold
@@ -51,8 +53,21 @@ class Transcriber:
                     self.transcribe_model = WhisperModel(self.model, device=self.process_device, compute_type="float32")
 
 
-    def get_player_response(self, say_goodbye):
-        if (self.debug_mode == '1') & (self.debug_use_mic == '0'):
+    def get_player_response(self, say_goodbye, radiant_dialogue="false"):
+        if radiant_dialogue == "true":
+            if self.call_count < 1:
+                logging.info('Running radiant dialogue')
+                transcribed_text = '*Please begin / continue a conversation topic (greetings are not needed). Ensure to change the topic if the current one is losing steam. The conversation should steer towards topics which reveal information about the characters and who they are, or instead drive forward conversations previously discussed in their memory.*'
+                self.call_count += 1
+            elif self.call_count <= 1:
+                logging.info('Ending radiant dialogue')
+                transcribed_text = '*Please wrap up the current topic between the NPCs in a natural way. Nobody is leaving, so no formal goodbyes.*'
+                self.call_count += 1
+            else:
+                logging.info('Radiant dialogue ended')
+                transcribed_text = self.end_conversation_keyword
+                self.call_count = 0
+        elif (self.debug_mode == '1') & (self.debug_use_mic == '0'):
             transcribed_text = self.default_player_response
         else:
             if self.mic_enabled == '1':


### PR DESCRIPTION
Added handling of radiant dialogue (conversations which don't include the player):

1. Edited multi_npc_prompt to consider whether the player is in the conversation (multi NPC) or not (radiant)
2. Added conditions to `main.py` to consider the radiant dialogue format
3. Added ability for player to "interrupt" radiant dialogue (ie stop streaming LLM response) and join the conversation
4. If radiant dialogue, player response is changed with radiant dialogue stage directions
5. Fixed bug with hotkey still being searched for despite its removal from config.ini
6. Added warning if model failed to load that `alternative_openai_api_base` may need to be changed in config.ini