### PR TITLE
Update setup.py to send api key as long as the api base is in https f…

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -93,7 +93,7 @@ def initialise(config_file, logging_file, secret_key_file, character_df_file, la
     config = config_loader.ConfigLoader(config_file)
 
     is_local = True
-    if (config.alternative_openai_api_base == 'none') or (config.alternative_openai_api_base == 'https://openrouter.ai/api/v1'):
+    if (config.alternative_openai_api_base == 'none') or ("https" in config.alternative_openai_api_base):
         is_local = False
     setup_openai_secret_key(secret_key_file, is_local)
     if is_local:


### PR DESCRIPTION
…ormat

-now that more services are running openai compatible api's it no longer makes sense to hard code openai and openrouter as only permitted services to send api key

-at the same time concerns have been expressed about floating API key out there on local network if someone forgets to clear it or regularly switches between openai and other services

-proposed solution is to check whether api base is none (openai) or has https in the URL.  This should enable services like mistral that have an openai API to work with Mantella, or other services that crop up and have openai compatible APIs.

-alternative would be not to care about https at all and just always send the key but it's hard to imagine why someone would require a real key on a non https site.