### PR TITLE
Fix to reload_conversation failing

### DIFF
--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -415,7 +415,7 @@ class GameStateManager:
         prompt = config.prompt
         if len(keys) > 1:
             prompt = config.multi_npc_prompt
-        context = latest_character.set_context(prompt, location, in_game_time, active_characters, token_limit)
+        context = latest_character.set_context(prompt, location, in_game_time, active_characters, token_limit, 'false')
 
         # add previous few back and forths from last conversation
         messages_wo_system_prompt = messages[1:]


### PR DESCRIPTION
# Fixed call to set_context in reload_conversation being done without radiant_dialogue parameter
- set to be always 'false', as radiant conversations can never reload
