### PR TITLE
Add names of NPCs to whisper prompt

### DIFF
--- a/main.py
+++ b/main.py
@@ -175,7 +175,8 @@ try:
                 transcript_cleaned = ''
                 transcribed_text = None
                 if conversation_ended.lower() != 'true':
-                    transcribed_text, say_goodbye = transcriber.get_player_response(say_goodbye, radiant_dialogue)
+                    all_names: str =  ", ".join(characters.active_characters.keys())
+                    transcribed_text, say_goodbye = transcriber.get_player_response(say_goodbye, all_names, radiant_dialogue)
 
                     game_state_manager.write_game_info('_mantella_player_input', transcribed_text)
 

--- a/src/stt.py
+++ b/src/stt.py
@@ -55,7 +55,7 @@ class Transcriber:
                     self.transcribe_model = WhisperModel(self.model, device=self.process_device, compute_type="float32")
 
 
-    def get_player_response(self, say_goodbye, radiant_dialogue="false"):
+    def get_player_response(self, say_goodbye, prompt: str, radiant_dialogue="false"):
         if radiant_dialogue == "true":
             if self.call_count < 1:
                 logging.info('Running radiant dialogue')
@@ -74,7 +74,7 @@ class Transcriber:
         else:
             if self.mic_enabled == '1':
                 # listen for response
-                transcribed_text = self.recognize_input()
+                transcribed_text = self.recognize_input(prompt)
             else:
                 # text input through console
                 if (self.debug_mode == '1') & (self.debug_use_mic == '1'):
@@ -97,14 +97,14 @@ class Transcriber:
         return transcribed_text, say_goodbye
 
 
-    def recognize_input(self):
+    def recognize_input(self, prompt: str):
         """
         Recognize input from mic and return transcript if activation tag (assistant name) exist
         """
         while True:
             self.game_state_manager.write_game_info('_mantella_status', 'Listening...')
             logging.info('Listening...')
-            transcript = self._recognize_speech_from_mic()
+            transcript = self._recognize_speech_from_mic(prompt)
             transcript_cleaned = utils.clean_text(transcript)
 
             conversation_ended = self.game_state_manager.load_data_when_available('_mantella_end_conversation', '')
@@ -119,16 +119,16 @@ class Transcriber:
             return transcript
     
 
-    def _recognize_speech_from_mic(self):
+    def _recognize_speech_from_mic(self, prompt: str):
         """
         Capture the words from the recorded audio (audio stream --> free text).
         Transcribe speech from recorded from `microphone`.
         """
         @utils.time_it
-        def whisper_transcribe(audio):
+        def whisper_transcribe(audio, prompt: str):
             # if using faster_whisper (default) return based on faster_whisper's code, if not assume player wants to use server mode and send query to whisper_url set by player.
             if self.whisper_type == 'faster_whisper':
-                segments, info = self.transcribe_model.transcribe(audio, task=self.task, language=self.language, beam_size=5, vad_filter=True)
+                segments, info = self.transcribe_model.transcribe(audio, task=self.task, language=self.language, beam_size=5, vad_filter=True, initial_prompt=prompt)
                 result_text = ' '.join(segment.text for segment in segments)
 
                 return result_text
@@ -140,7 +140,8 @@ class Transcriber:
                 else:
                     headers = {"Authorization": "Bearer apikey",}
                 data = {'model': self.model}
-                files = {'file': open(audio, 'rb')}
+                files = {'file': open(audio, 'rb'),
+                         "prompt": prompt}
                 response = requests.post(url, headers=headers, files=files, data=data)
                 response_data = json.loads(response.text)
                 if 'text' in response_data:
@@ -156,7 +157,7 @@ class Transcriber:
         with open(audio_file, 'wb') as file:
             file.write(audio.get_wav_data(convert_rate=16000))
         
-        transcript = whisper_transcribe(audio_file)
+        transcript = whisper_transcribe(audio_file, prompt)
         logging.info(transcript)
 
         return transcript


### PR DESCRIPTION
# Add names of NPCs to whisper prompt
- adds the names of NPCs in the conversation to the prompts of faster-whisper and whisper.cpp
- This improves the recognition of spoken names
- Other Skyrim specific words could be added in the future

# Examples

Without prompts, *Brelyna* is recognised as `Brillina`, `Berliner` and many more different names

`prompt = "Brelyna Maryon"`
Transcript:
> `Tilly smiles at Brelyna. Do you want to have a drink at the tavern?`

Adding J'zargo to the conversation, first iteration when he is already selected in Skyrim but not added to Mantella yet.
`prompt = "Brelyna Maryon"`
Transcript:
> `Hello, Brelyna. Hello, Jizzago. How are you two?`

Next reply, after J'zargo has been added in Mantella as well.
`prompt = "Brelyna Maryon, J'zargo"`
Transcript:
> `How does life at the college treat you, J'zargo and Brelyna?`