### PR TITLE
LLM service auto resolver

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -181,20 +181,16 @@ max_response_sentences = 999
 ;   Default: 1.0
 wait_time_buffer = 1.0
 
-; alternative_openai_api_base
-;   If you are using openai's services, leave this alone, otherwise you can change this variable to another base_api that uses openai's api
-;   For example, if you have a local llm framework or online framework that allows you to use a different url to access openai api functions, you can enter the base_api url here 
-;   Your alternative api_base must support openai's python streaming protocol.
-;   Examples: 
-;       http://127.0.0.1:5000/v1 for textgenwebui using the default openai extension
-;       http://127.0.0.1:5001/v1 for koboldcpp (after version 1.46 of koboldcpp which supports the openai API)
-;       http://localhost:8080/v1 using the default endpoint for Local.ai
-;       https://openrouter.ai/api/v1 for openrouter
-;       http://localhost:5001/v1 for using koboldcpp locally or the url you obtain from the koboldcpp google colab notebook with /v1 added at the end.
-;   Ensure that you have the correct secret key set in GPT_SECRET_KEY.txt for the service you are using
-;   Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running mantella
-;   Leave this value as none to use the normal openai chat gpt models.
-alternative_openai_api_base = none
+; llm_api
+;   Options: auto, OpenRouter, OpenAI, Kobold, textgenwebui
+;   Selects the LLM service to connect to
+;   By default, the service will be automatically determined based on whether Kobold / textgenwebui is running, and if neither are running, based on the model selected
+;   If you would prefer to explicitly select the service, you can do so by setting llm_api to one of the options above
+;   Ensure that you have the correct secret key set in GPT_SECRET_KEY.txt for the service you are using (if using OpenRouter or OpenAI)
+;   Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running Mantella
+;   Advanced: You can also set the desired endpoint directly, eg http://127.0.0.1:5001/v1 for Kobold
+;   Default: auto
+llm_api = auto
 
 ; custom_token_count
 ;   If the model chosen is not recognised by Mantella, the token count for the given model will default to this number

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -120,7 +120,7 @@ https://github.com/art-from-the-machine/Mantella#issues-qa
             self.max_response_sentences = int(config['LanguageModel']['max_response_sentences'])
             self.llm = config['LanguageModel']['model']
             self.wait_time_buffer = float(config['LanguageModel']['wait_time_buffer'])
-            self.alternative_openai_api_base = config['LanguageModel']['alternative_openai_api_base']
+            self.llm_api = config['LanguageModel']['llm_api']
             self.custom_token_count = config['LanguageModel']['custom_token_count']
             self.temperature = float(config['LanguageModel']['temperature'])
             self.top_p = float(config['LanguageModel']['top_p'])

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -89,7 +89,7 @@ class openai_client:
         # if using an alternative API, use encoding for GPT-3.5 by default
         # NOTE: this encoding may not be the same for all models, leading to incorrect token counts
         #       this can lead to the token limit of the given model being overrun
-        if config.llm_api != 'none':
+        if config.endpoint != 'none':
             chosenmodel = 'gpt-3.5-turbo'
         try:
             self.__encoding = tiktoken.encoding_for_model(chosenmodel)


### PR DESCRIPTION
Reimagined version of `alternative_openai_api_base` (now `llm_api`) which simplifies the LLM service connection process:

- `auto` setting: Mantella now auto-resolves the LLM service to connect to. The order is: check if Kobold is running -> check if textgenwebui is running -> check if `model` setting in config.ini has a slash in it's name (if it does, it is an OpenRouter model, if not, OpenAI)
- Named services: Players now only have to set the name of the service they would like to connect to ("OpenAI", "Kobold" etc), removing the need to copy paste long scary URLs

Solves https://github.com/art-from-the-machine/Mantella/issues/145