### PR TITLE
Added context to save_conversation so that reloads force a summary length check

### DIFF
--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -215,9 +215,9 @@ class context:
                 conversation_summaries=content[1]
                 )
             if self.__client.calculate_tokens_from_text(result) < self.__client.token_limit * self.__token_limit_percent:
-                logging.log(23, f'Prompt sent to LLM: {result}')
+                logging.log(23, f'Prompt sent to LLM: {result.strip()}')
                 return result
             
 
-        logging.log(23, f'Prompt sent to LLM: {prompt}')
+        logging.log(23, f'Prompt sent to LLM: {prompt.strip()}')
         return prompt #This should only trigger, if the default prompt even without bios and conversation_summaries is too long

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -112,7 +112,7 @@ class conversation:
             self.__messages.add_message(assistant_message(config.end_conversation_keyword+'.', self.__context.npcs_in_conversation.get_all_names(), is_system_generated_message=True))
             
             # save conversation
-            self.__save_conversation()
+            self.__save_conversation(is_reload=False)
             
             self.__has_already_ended = True
             self.__game_manager.end_conversation()
@@ -141,11 +141,11 @@ class conversation:
             new_message.is_system_generated_message = True # Flag message containing goodbye as a system message to exclude from summary
             self.end()
 
-    def __save_conversation(self):
+    def __save_conversation(self, is_reload):
         """Saves conversation log and state for each NPC in the conversation"""
         for npc in self.__context.npcs_in_conversation.get_all_characters():
             npc.save_conversation_log(self.__messages)
-        self.__rememberer.save_conversation_state(self.__messages, self.__context.npcs_in_conversation)
+        self.__rememberer.save_conversation_state(self.__messages, self.__context.npcs_in_conversation, is_reload)
 
     @utils.time_it
     def __reload_conversation(self):
@@ -166,7 +166,7 @@ class conversation:
             collecting_thoughts_response = collecting_thoughts_text+'.'
         self.__messages.add_message(assistant_message(collecting_thoughts_response, self.__context.npcs_in_conversation.get_all_names(), is_system_generated_message=True))
         # Save conversation
-        self.__save_conversation()
+        self.__save_conversation(is_reload=True)
         # Reload
         new_prompt = self.__conversation_type.generate_prompt(self.__context)
         self.__messages.reload_message_thread(new_prompt, 8)

--- a/src/remember/remembering.py
+++ b/src/remember/remembering.py
@@ -18,7 +18,7 @@ class remembering(ABC):
         pass
 
     @abstractmethod
-    def save_conversation_state(self, messages: message_thread, npcs_in_conversation: Characters):
+    def save_conversation_state(self, messages: message_thread, npcs_in_conversation: Characters, is_reload=False):
         """Saves the current state of the conversation.
 
         Args:

--- a/src/remember/summaries.py
+++ b/src/remember/summaries.py
@@ -43,7 +43,7 @@ class summaries(remembering):
                         result += f"{character.name}: {previous_conversation_summaries}"
         return result
 
-    def save_conversation_state(self, messages: message_thread, npcs_in_conversation: Characters):
+    def save_conversation_state(self, messages: message_thread, npcs_in_conversation: Characters, is_reload=False):
         summary = ''
         non_generic_npc = []
         for npc in npcs_in_conversation.get_all_characters():
@@ -52,9 +52,9 @@ class summaries(remembering):
             else:
                 non_generic_npc.append(npc)
         for npc in non_generic_npc:            
-            if len(summary) < 1:
+            if len(summary) < 1: # if a summary has not already been generated, make one
                 summary = self.__create_new_conversation_summary(messages, npc.name)
-            if len(summary) > 0:# Should for what ever reason the first summary to fail, don't even try to continue here
+            if len(summary) > 0 or is_reload: # if a summary has been generated, give the same summary to all NPCs
                 self.__append_new_conversation_summary(summary, npc)
 
     def __create_new_conversation_summary(self, messages: message_thread, npc_name: str) -> str:
@@ -86,9 +86,10 @@ class summaries(remembering):
             os.makedirs(directory, exist_ok=True)
             previous_conversation_summaries = ''
        
-        conversation_summaries = previous_conversation_summaries + new_summary
-        with open(npc.conversation_summary_file, 'w', encoding='utf-8') as f:
-            f.write(conversation_summaries)
+        if len(new_summary) > 0:
+            conversation_summaries = previous_conversation_summaries + new_summary
+            with open(npc.conversation_summary_file, 'w', encoding='utf-8') as f:
+                f.write(conversation_summaries)
 
         summary_limit = round(self.__client.token_limit*self.__summary_limit_pct,0)
 


### PR DESCRIPTION
Conversation reloads are triggered when a conversation gets too long. A bug in the code caused the length of NPC summaries to not be evaluated if a reload is needed early in the conversation. 

Summaries are not created for conversations that are too short (design choice), yet if the token count goes over a given LLM's limit and a summary cannot be created, then an endless loop occurs where the conversation is constantly at the limit and cannot be shortened. This PR fixes this problem by allowing an extra check to see if the length of previous summaries is too long, and if so, shorten them.