### PR TITLE
fix: check end_conversation.txt when waiting for text input

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ try:
                 talk.add_character(character)
 
             with open(f'{config.game_path}/_mantella_end_conversation.txt', 'r', encoding='utf-8') as f:
-                if f.readline().strip() == 'true':
+                if f.readline().strip().lower() == 'true':
                     talk.end()
 
             # proceed the conversation

--- a/src/stt.py
+++ b/src/stt.py
@@ -144,8 +144,8 @@ class Transcriber:
     def _get_text_input(self):
         # text input through console
         if (self.debug_mode == '1') & (self.debug_use_default_player_response == '0'):
-            transcribed_text = input('\nWrite player\'s response: ')
-            logging.log(self.loglevel, f'Player wrote "{transcribed_text}"')
+            text = input('\nWrite player\'s response: ')
+            logging.log(self.loglevel, f'Player wrote "{text}"')
         # await text input from the game
         else:
             self.game_state_manager.write_game_info('_mantella_text_input', '')
@@ -162,7 +162,7 @@ class Transcriber:
             self.game_state_manager.write_game_info('_mantella_text_input', '')
             self.game_state_manager.write_game_info('_mantella_text_input_enabled', 'False')
 
-            return text
+        return text
 
     @staticmethod
     def activation_name_exists(transcript_cleaned, activation_name):

--- a/src/stt.py
+++ b/src/stt.py
@@ -5,11 +5,13 @@ import src.utils as utils
 import requests
 import json
 import io
+import time
 
 class Transcriber:
     def __init__(self, game_state_manager, config, api_key: str):
         self.loglevel = 27
         self.game_state_manager = game_state_manager
+        self.game_path = config.game_path
         self.mic_enabled = config.mic_enabled
         self.language = config.stt_language
         self.task = "transcribe"
@@ -64,17 +66,7 @@ class Transcriber:
                 # listen for response
                 transcribed_text = self.recognize_input(prompt)
             else:
-                # text input through console
-                if (self.debug_mode == '1') & (self.debug_use_default_player_response == '0'):
-                    transcribed_text = input('\nWrite player\'s response: ')
-                    logging.log(self.loglevel, f'Player wrote "{transcribed_text}"')
-                # await text input from the game
-                else:
-                    self.game_state_manager.write_game_info('_mantella_text_input', '')
-                    self.game_state_manager.write_game_info('_mantella_text_input_enabled', 'True')
-                    transcribed_text = self.game_state_manager.load_data_when_available('_mantella_text_input', '')
-                    self.game_state_manager.write_game_info('_mantella_text_input', '')
-                    self.game_state_manager.write_game_info('_mantella_text_input_enabled', 'False')
+                transcribed_text = self._get_text_input()
 
         if (self.debug_mode == '1') & (self.debug_exit_on_first_exchange == '1'):
             if say_goodbye:
@@ -149,6 +141,28 @@ class Transcriber:
 
         return transcript
 
+    def _get_text_input(self):
+        # text input through console
+        if (self.debug_mode == '1') & (self.debug_use_default_player_response == '0'):
+            transcribed_text = input('\nWrite player\'s response: ')
+            logging.log(self.loglevel, f'Player wrote "{transcribed_text}"')
+        # await text input from the game
+        else:
+            self.game_state_manager.write_game_info('_mantella_text_input', '')
+            self.game_state_manager.write_game_info('_mantella_text_input_enabled', 'True')
+            text = ''
+            while text == '':
+                with open(f'{self.game_path}/_mantella_end_conversation.txt', 'r', encoding='utf-8') as f:
+                    if f.readline().strip().lower() == 'true':
+                        return self.end_conversation_keyword
+                with open(f'{self.game_path}/_mantella_text_input.txt', 'r', encoding='utf-8') as f:
+                    text = f.readline().strip()
+                # decrease stress on CPU while waiting for file to populate
+                time.sleep(0.01)
+            self.game_state_manager.write_game_info('_mantella_text_input', '')
+            self.game_state_manager.write_game_info('_mantella_text_input_enabled', 'False')
+
+            return text
 
     @staticmethod
     def activation_name_exists(transcript_cleaned, activation_name):


### PR DESCRIPTION
This PR resolves an issue where Mantella hangs when waiting for text input when the player has already ended the conversation.

Instead of calling `GameStateManager.load_data_when_available`, `Transcriber` has a new function `_get_text_input` that polls both `_mantella_text_input.txt` and `_mantella_end_conversation.txt` to ensure that it doesn't end up in an endless loop.

I also fixed an instance where `_mantella_end_conversation.txt` was being checked for the value `true` without first converting it to lower case.

I've only tested this fix with Skyrim and Skyrim VR but not with Fallout 4 or Fallout 4 VR.

Fixes #241