### PR TITLE
Redefined how token limits are calculated

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ try:
     )
 
     token_limit = client.token_limit
-    token_limit_percent: float = 0.45
+    starting_prompt_token_limit_percent: float = 0.5
     mantella_version = '0.11'
     logging.log(24, f'\nMantella v{mantella_version}')
 
@@ -66,12 +66,12 @@ try:
 
         #base setup for conversation
         num_characters_selected = 0
-        context_for_conversation = context(config, rememberer, language_info, client, token_limit_percent)
+        context_for_conversation = context(config, rememberer, language_info, client, starting_prompt_token_limit_percent)
 
         with open(f'{config.game_path}/_mantella_radiant_dialogue.txt', 'r', encoding='utf-8') as f:
             is_radiant_dialogue = f.readline().strip().lower() == 'true'
 
-        talk = conversation(context_for_conversation, transcriber, synthesizer, game_state_manager, chat_manager, rememberer, is_radiant_dialogue, token_limit, token_limit_percent)
+        talk = conversation(context_for_conversation, transcriber, synthesizer, game_state_manager, chat_manager, rememberer, is_radiant_dialogue, token_limit, config.max_tokens)
 
         while True: # Start conversation loop
             try:

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -12,14 +12,14 @@ from src.config_loader import ConfigLoader
 class context:
     """Holds the context of a conversation
     """
-    def __init__(self, config: ConfigLoader, rememberer: remembering, language: dict[Hashable, str], client: openai_client, token_limit_percent: float = 0.45) -> None:
+    def __init__(self, config: ConfigLoader, rememberer: remembering, language: dict[Hashable, str], client: openai_client, token_limit_percent: float) -> None:
         self.__npcs_in_conversation: Characters = Characters()
         self.__config: ConfigLoader = config
         self.__rememberer: remembering = rememberer
         self.__language: dict[Hashable, str] = language
         self.__client: openai_client = client #Just passed in for the moment to measure the length of the system message, maybe better solution in the future?
         self.__ingame_time: int = 12
-        self.__token_limit_percent = token_limit_percent
+        self.__prompt_token_limit_percent = token_limit_percent
         self.__should_switch_to_multi_npc_conversation: bool = False
 
         if config.game == "Fallout4" or config.game == "Fallout4VR":
@@ -214,7 +214,7 @@ class context:
                 conversation_summary=content[1],
                 conversation_summaries=content[1]
                 )
-            if self.__client.calculate_tokens_from_text(result) < self.__client.token_limit * self.__token_limit_percent:
+            if self.__client.calculate_tokens_from_text(result) < self.__client.token_limit * self.__prompt_token_limit_percent:
                 logging.log(23, f'Prompt sent to LLM ({self.__client.calculate_tokens_from_text(result)} tokens): {result.strip()}')
                 return result
             


### PR DESCRIPTION
Token limit calculations have been repainted in a couple of ways:

- `token_limit_percent` has been renamed in main.py and context.py to `starting_prompt_token_limit_percent` to better reflect what the percentage is calculated against. This percentage has been bumped from 45% to 50%. ie at most, the starting prompt (including the NPC bio and long term memories) can account for up to 50% of a conversation's token limit
- `reload_conversation()` in conversation.py is no longer triggered by percentage calculations. Instead, it is triggered when the conversation so far (including the starting prompt, NPC bio, and long term memories) + `max_response_tokens` + 250 tokens exceeds the given LLM's token limit. `max_response_tokens` is added because the calculation needs to predict whether the next response will exceed the token limit, not the current response. 250 tokens are added to act as a safety buffer, accounting for the player's input as well as the slight differences in token calculations across various LLMs