### PR TITLE
Better voice model loading

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ try:
         config.mic_enabled = '1' if mcm_mic_enabled == 'TRUE' else '0'
 
     synthesizer = tts.Synthesizer(config,character_df)
-    game_state_manager = game_manager.GameStateManager(config.game_path, config.game)
+    game_state_manager = game_manager.GameStateManager(config.game_path, config.game, synthesizer)
     chat_manager = output_manager.ChatManager(game_state_manager, config, synthesizer, client)
     transcriber = stt.Transcriber(game_state_manager, config, client.api_key)    
     rememberer: remembering = summaries(config.memory_prompt, config.resummarize_prompt, client, language_info['language'], config.game)

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -617,7 +617,7 @@ class ChatManager:
                                     try:
                                         audio_file = self.__tts.synthesize(self.active_character.voice_model, ' ' + sentence + ' ', self.active_character.in_game_voice_model, self.active_character.csv_in_game_voice_model, self.active_character.voice_accent, self.active_character.is_in_combat, self.active_character.advanced_voice_model)
                                     except Exception as e:
-                                        logging.error(f"xVASynth Error: {e}")
+                                        logging.error(f"TTS Error: {e}")
 
                                     # Put the audio file path in the sentence_queue
                                     await sentence_queue.put([audio_file, sentence])
@@ -652,8 +652,10 @@ class ChatManager:
                                         break
                 break
             except Exception as e:
-                if e.code in [401, 'invalid_api_key']: # incorrect API key
+                if (hasattr(e, 'code')) and (e.code in [401, 'invalid_api_key']): # incorrect API key
                     logging.error(f"Invalid API key. Please ensure you have selected the right model for your service (OpenAI / OpenRouter) via the 'model' setting in MantellaSoftware/config.ini. If you are instead trying to connect to a local model, please ensure the service is running.")
+                elif isinstance(e, UnboundLocalError):
+                    logging.error('No voice file generated for voice line. Please check your TTS service for errors. The reason for this error is often because a voice model could not be found.')
                 else:
                     logging.error(f"LLM API Error: {e}")
                 error_response = "I can't find the right words at the moment."


### PR DESCRIPTION
NPC voice models are now loaded at the time of the character being loaded, rather than when they first speak. This allows Mantella to change the NPC's voice model to a generic one if the specified model isn't found.

If no voice models can be loaded, a more helpful error message displays to say as much, rather than giving a generic LLM API error.