### PR TITLE
Allow skipping TTS generation (#266)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -93,7 +93,7 @@ max_response_sentences = 999
 
 [Speech]
 ; tts_service
-;   Options: xVASynth, XTTS
+;   Options: xVASynth, XTTS, None
 tts_service = xVASynth
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ myst-parser==2.0.0
 sphinx-design==0.5.0
 sphinxcontrib-youtube==1.4.1
 furo==2023.9.10
+silentwav==0.10


### PR DESCRIPTION
This allows specifying generating only subtitles rather than text-to-speech, so long as the `facefx_folder` is set (automatically or otherwise; if the xVASynth or XTTS folders for FaceFXWrapper exist, then those will be used). It is annoying that we still need FaceFXWrapper even for silent audio files, but it's ultimately not too much of a price, considering I can't find documentation on the .lip format and this avoids risking any crashes due to missing files.