### PR TITLE
Allow NPC roleplaying action narrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ main.exe
 data/advanced_voice_model_data_log_xtts.csv
 data/csv_voice_folder_data_log_xtts.csv
 data/voice_model_data_log_xtts.csv
+.idea/

--- a/config.ini
+++ b/config.ini
@@ -209,6 +209,11 @@ memory_prompt = You are tasked with summarizing the conversation between {name} 
 resummarize_prompt = You are tasked with summarizing the conversation history between {name} (the assistant) and the player (the user) / other characters. These conversations take place in {game}.
     Each paragraph represents a conversation at a new point in time. Please summarize these conversations into a single paragraph in {language}.
 
+; allow_action_narration
+;   Mantella will not get rid of sentences with asterisks (*) surrounding sentences, which would typically describe role playing actions
+;   Instead, Mantella will just get rid of the asterisks and the NPC will narrate the action taken, i.e '*starts dancing to the music*' is narrated as 'starts dancing to the music'.
+;   Options: 0, 1
+allow_action_narration = 0
 
 [Language.Advanced]
 ; goodbye_npc_response

--- a/src/config_loader.py
+++ b/src/config_loader.py
@@ -185,6 +185,7 @@ https://github.com/art-from-the-machine/Mantella#issues-qa
             self.radiant_end_prompt = config['Prompt']['radiant_end_prompt']
             self.memory_prompt = config['Prompt']['memory_prompt']
             self.resummarize_prompt = config['Prompt']['resummarize_prompt']
+            self.allow_action_narration = int(config['Prompt']['allow_action_narration'])
             pass
         except Exception as e:
             logging.error('Parameter missing/invalid in config.ini file!')

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -33,6 +33,7 @@ class ChatManager:
         self.offended_npc_response = config.offended_npc_response
         self.forgiven_npc_response = config.forgiven_npc_response
         self.follow_npc_response = config.follow_npc_response
+        self.allow_action_narration = True if config.allow_action_narration == 1 else False
         self.wait_time_buffer = config.wait_time_buffer
         self.root_mod_folder = config.game_path
         self.__tts: Synthesizer = tts
@@ -479,7 +480,10 @@ class ChatManager:
             if ('*' in sentence):
                 # Check if sentence contains two asterisks
                 asterisk_check = re.search(r"(?<!\*)\*(?!\*)[^*]*\*(?!\*)", sentence)
-                if asterisk_check:
+                if self.allow_action_narration:
+                    logging.info(f"Removed asterisks from text for narration: {sentence}")
+                    sentence = sentence.replace('*', '')
+                elif asterisk_check:
                     logging.info(f"Removed asterisks text from response: {sentence}")
                     # Remove text between two asterisks
                     sentence = re.sub(r"(?<!\*)\*(?!\*)[^*]*\*(?!\*)", "", sentence)


### PR DESCRIPTION
Provide an option within the config to allow role playing actions to be read out loud. This will make it so Mantella does not remove asterisks (*) from AI responses, and hence the NPC will say it loud. By default its disabled.