### PR TITLE
PR/image analysis

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def main():
         mantella_http_server = http_server()
 
         #start the http server
-        conversation = mantella_route(config, 'GPT_SECRET_KEY.txt', language_info, should_debug_http)
+        conversation = mantella_route(config, 'GPT_SECRET_KEY.txt','IMAGE_GPT_SECRET_KEY.txt', language_info, should_debug_http)
         stt = stt_route(config, 'GPT_SECRET_KEY.txt', should_debug_http)
         ui = StartUI(config)
         routes: list[routeable] = [conversation, stt, ui]

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -209,7 +209,32 @@ class ConfigLoader:
             self.frequency_penalty = self.__definitions.get_float_value("frequency_penalty")
             self.max_tokens = self.__definitions.get_int_value("max_tokens")
 
-            
+            #IMAGE_LLM
+            self.image_analysis_skyrim_filepath = self.__definitions.get_string_value("image_analysis_skyrim_filepath")
+            self.image_analysis_skyrim_vr_filepath = self.__definitions.get_string_value("image_analysis_skyrim_vr_filepath")
+            self.image_analysis_fallout4_filepath = self.__definitions.get_string_value("image_analysis_fallout4_filepath")
+            self.image_analysis_fallout4_vr_filepath = self.__definitions.get_string_value("image_analysis_fallout4_vr_filepath")
+            self.image_analysis_iterative_querying = self.__definitions.get_bool_value("image_analysis_iterative_querying")
+            self.image_max_response_sentences = self.__definitions.get_int_value("image_max_response_sentences")
+            self.image_llm = self.__definitions.get_string_value("image_llm_model")
+            self.image_llm_api = self.__definitions.get_string_value("image_llm_api")
+            if self.image_llm_api == "Custom":
+                self.image_llm_api = self.__definitions.get_string_value("image_llm_custom_service_url")
+            self.image_llm_custom_token_count = self.__definitions.get_int_value("image_llm_custom_token_count")
+            self.image_llm_temperature = self.__definitions.get_float_value("image_llm_temperature")
+            self.image_llm_top_p = self.__definitions.get_float_value("image_llm_top_p")
+
+            image_llm_stop_value = self.__definitions.get_string_value("image_llm_stop")
+            if ',' in image_llm_stop_value:
+                # If there are commas in the stop value, split the string by commas and store the values in a list
+                self.image_llm_stop = image_llm_stop_value.split(',')
+            else:
+                # If there are no commas, put the single value into a list
+                self.image_llm_stop = [stop_value]
+
+            self.image_llm_frequency_penalty = self.__definitions.get_float_value("image_llm_frequency_penalty")
+            self.image_llm_max_tokens = self.__definitions.get_int_value("image_llm_max_tokens")
+
 
             self.remove_mei_folders = self.__definitions.get_bool_value("remove_mei_folders")
             #Debugging
@@ -245,6 +270,8 @@ class ConfigLoader:
             self.radiant_end_prompt = self.__definitions.get_string_value("radiant_end_prompt")
             self.memory_prompt = self.__definitions.get_string_value("memory_prompt")
             self.resummarize_prompt = self.__definitions.get_string_value("resummarize_prompt")
+            self.image_llm_direct_prompt = self.__definitions.get_string_value("image_llm_direct_prompt")
+            self.image_llm_iterative_prompt = self.__definitions.get_string_value("image_llm_iterative_prompt")
             pass
         except Exception as e:
             logging.error('Parameter missing/invalid in config.ini file!')

--- a/src/config/definitions/image_llm_definitions.py
+++ b/src/config/definitions/image_llm_definitions.py
@@ -1,0 +1,103 @@
+from src.config.types.config_value import ConfigValue, ConvigValueTag
+from src.config.types.config_value_float import ConfigValueFloat
+from src.config.types.config_value_int import ConfigValueInt
+from src.config.types.config_value_selection import ConfigValueSelection
+from src.config.types.config_value_string import ConfigValueString
+from src.config.types.config_value_bool import ConfigValueBool
+
+
+class ImageLLMDefinitions:
+    @staticmethod
+    def get_image_analysis_skyrim_filepath_config_value() -> ConfigValue:
+        description = """ Settings for for the filepath of Skyrim (desktop) directory where the executable is located. 
+        If you are not using Skyrim (desktop), you may retain the default setting.
+        Copy the complete filepath from your OS file explorer. """
+        return ConfigValueString("image_analysis_skyrim_filepath","Set the filepath to Skyrim (desktop) directory",description,"C:\Games\Steam\steamapps\common\Skyrim Special Edition")
+
+    def get_image_analysis_skyrim_vr_filepath_config_value() -> ConfigValue:
+        description = """ Settings for for the filepath of Steam directory where the steam screenshots are stored. 
+        They should located inside your steam directory -> userdata -> Your personal user number -> 760 -> remote -> 611670 -> screenshots
+        If you are not using Skyrim (VR), you may retain the default setting.
+        Copy the complete filepath from your OS file explorer. """
+        return ConfigValueString("image_analysis_skyrim_vr_filepath","Set the filepath to Steam Screenshot directory for Skyrim VR",description,"C:\\Games\\Steam\\userdata\\YOUR_USER_NUMBER_HERE\\760\\remote\\611670\\screenshots")
+    
+    def get_image_analysis_fallout4_filepath_config_value() -> ConfigValue:
+        description = """ Settings for for the filepath of Fallout 4 (desktop) directory where the executable is located. 
+        If you are not using Fallout 4 (desktop), you may retain the default setting.
+        Copy the complete filepath from your OS file explorer. """
+        return ConfigValueString("image_analysis_fallout4_filepath","Set the filepath to Fallout 4 (desktop) directory",description,"C:\Games\Steam\steamapps\common\Fallout 4")
+
+    def get_image_analysis_fallout4_vr_filepath_config_value() -> ConfigValue:
+        description = """ Settings for for the filepath of Steam directory where the steam screenshots are stored. 
+        They should located inside your steam directory -> userdata -> Your personal user number -> 760 -> remote -> 611660 -> screenshots
+        If you are not using Fallout 4 (VR), you may retain the default setting.
+        Copy the complete filepath from your OS file explorer. """
+        return ConfigValueString("image_analysis_fallout4_vr_filepath","Set the filepath to Steam Screenshot directory for Fallout 4 VR",description,"C:\\Games\\Steam\\userdata\\YOUR_USER_NUMBER_HERE\\760\\remote\\611660\\screenshots")
+
+    def get_image_analysis_iterative_querying_config_value() -> ConfigValue:
+        description = """ Settings for the LLM providers and the LLMs themselves.
+If you're using iterative querying input 1
+if you're sending the image and the LLM prompt all at once input 0 , then the values from [LLM] will be used for image queries except for the prompts
+"""
+        return ConfigValueBool("image_analysis_iterative_querying","Use iterative querying",description,False)
+ 
+    @staticmethod
+    def get_image_llm_model_config_value() -> ConfigValue:
+        model_description = """ model
+   Options:
+   - OpenRouter: see https://openrouter.ai/docs#models. Take the value displayed under the model heading (eg anthropic/claude-3-sonnet)
+   - OpenAI: gpt-4-0125-preview, gpt4-o
+   Local model users can ignore this setting as you will instead select your model directly in Kobold / Text generation web UI
+   Remember to change your secret key in IMAGE_GPT_SECRET_KEY.txt when switching between OpenRouter and OpenAI services!"""
+        return ConfigValueString("image_llm_model","Image LLM Model",model_description,"gpt-4o")
+    
+    @staticmethod
+    def get_image_llm_max_response_sentences_config_value() -> ConfigValue:
+        return ConfigValueInt("image_max_response_sentences","Max sentences per response","The maximum number of sentences returned by the image LLM on each response. Lower this value to reduce waffling.\nNote: The setting number_words_tts takes precedence over this setting",999,1,999)
+    
+    @staticmethod
+    def get_image_llm_api_config_value() -> ConfigValue:
+        description = """Selects the LLM service to connect to
+            By default, the service will be automatically determined based on whether Kobold / textgenwebui is running, and if neither are running, based on the model selected
+            If you would prefer to explicitly select the service, you can do so by setting llm_api to one of the options above
+            Ensure that you have the correct secret key set in IMAGE_GPT_SECRET_KEY.txt for the service you are using (if using OpenRouter or OpenAI)
+            Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running Mantella
+            Choosing 'Custom' will instead use the URL from the 'LLM Custom Service Url' config value"""
+        return ConfigValueSelection("image_llm_api","LLM service",description, "auto", ["auto", "OpenRouter", "OpenAI", "Kobold", "textgenwebui", "Custom"],tags=[ConvigValueTag.advanced])
+    
+    @staticmethod
+    def get_image_llm_custom_service_url_config_value() -> ConfigValue:
+        description = """If selected 'Custom' for 'LLM service', you can enter the url to the custom service here. 
+                        A custom LLM service is expected to provide an OpenAI API compatible endpoint"""
+        return ConfigValueString("image_llm_custom_service_url","LLM custom service url",description, "http://127.0.0.1:5001/v1",tags=[ConvigValueTag.advanced])
+    
+    @staticmethod
+    def get_image_llm_custom_token_count_config_value() -> ConfigValue:
+        description = """If the model chosen is not recognised by Mantella, the token count for the given model will default to this number
+                    If this is not the correct token count for your chosen model, you can change it here
+                    Keep in mind that if this number is greater than the actual token count of the model, then Mantella will crash if a given conversation exceeds the model's token limit"""
+        return ConfigValueInt("image_llm_custom_token_count","Custom token count",description, 4096, 4096, 9999999,tags=[ConvigValueTag.advanced])
+    
+    @staticmethod
+    def get_image_llm_temperature_config_value() -> ConfigValue:
+        return ConfigValueFloat("image_llm_temperature","Temperature","", 1.0, 0, 2,tags=[ConvigValueTag.advanced])
+    
+    @staticmethod
+    def get_image_llm_top_p_config_value() -> ConfigValue:
+        return ConfigValueFloat("image_llm_top_p","Top p","", 1.0, 0, 1,tags=[ConvigValueTag.advanced])
+    
+    @staticmethod
+    def get_image_llm_stop_config_value() -> ConfigValue:
+        description = """A list of up to FOUR strings, by default only # is used
+                        If you want more than one stopping string use this format: string1,string2,string3,string4"""
+        return ConfigValueString("image_llm_stop","Stop",description, "#",tags=[ConvigValueTag.advanced])
+    
+    @staticmethod
+    def get_image_llm_frequency_penalty_config_value() -> ConfigValue:
+        return ConfigValueFloat("image_llm_frequency_penalty","Frequency penalty","", 0, -2, 2,tags=[ConvigValueTag.advanced])
+    
+    @staticmethod
+    def get_image_llm_max_tokens_config_value() -> ConfigValue:
+        return ConfigValueInt("image_llm_max_tokens","Max tokens","Lowering this value can sometimes result in empty responses", 250, 1, 999999,tags=[ConvigValueTag.advanced])
+
+    

--- a/src/config/definitions/image_llm_definitions.py
+++ b/src/config/definitions/image_llm_definitions.py
@@ -35,9 +35,9 @@ class ImageLLMDefinitions:
         return ConfigValueString("image_analysis_fallout4_vr_filepath","Set the filepath to Steam Screenshot directory for Fallout 4 VR",description,"C:\\Games\\Steam\\userdata\\YOUR_USER_NUMBER_HERE\\760\\remote\\611660\\screenshots")
 
     def get_image_analysis_iterative_querying_config_value() -> ConfigValue:
-        description = """ Settings for the LLM providers and the LLMs themselves.
-If you're using iterative querying input 1
-if you're sending the image and the LLM prompt all at once input 0 , then the values from [LLM] will be used for image queries except for the prompts
+        description = """ Selecting this will mean that Mantella will ask a LLM for an image description then make a second request to obtain a NPC response, the second request can be from a entirely different LLM.
+If you're using iterative querying input True (or check the box)
+if you're sending the image and the LLM prompt all at once input False (or uncheck the box) , then the values from [LLM] will be used for image queries except for the prompts
 """
         return ConfigValueBool("image_analysis_iterative_querying","Use iterative querying",description,False)
  
@@ -45,8 +45,8 @@ if you're sending the image and the LLM prompt all at once input 0 , then the va
     def get_image_llm_model_config_value() -> ConfigValue:
         model_description = """ model
    Options:
-   - OpenRouter: see https://openrouter.ai/docs#models. Take the value displayed under the model heading (eg anthropic/claude-3-sonnet)
-   - OpenAI: gpt-4-0125-preview, gpt4-o
+   - OpenRouter: see https://openrouter.ai/docs#models. Take the value displayed under the model heading, the model must be capable of image analysis on an OpenAI compatible endpoint.
+   - OpenAI: gpt-4-0125-preview, gpt-4o
    Local model users can ignore this setting as you will instead select your model directly in Kobold / Text generation web UI
    Remember to change your secret key in IMAGE_GPT_SECRET_KEY.txt when switching between OpenRouter and OpenAI services!"""
         return ConfigValueString("image_llm_model","Image LLM Model",model_description,"gpt-4o")
@@ -63,7 +63,7 @@ if you're sending the image and the LLM prompt all at once input 0 , then the va
             Ensure that you have the correct secret key set in IMAGE_GPT_SECRET_KEY.txt for the service you are using (if using OpenRouter or OpenAI)
             Note that for some services, like textgenwebui, you must enable the openai extension and have the model you want to use preloaded before running Mantella
             Choosing 'Custom' will instead use the URL from the 'LLM Custom Service Url' config value"""
-        return ConfigValueSelection("image_llm_api","LLM service",description, "auto", ["auto", "OpenRouter", "OpenAI", "Kobold", "textgenwebui", "Custom"],tags=[ConvigValueTag.advanced])
+        return ConfigValueSelection("image_llm_api","LLM service",description, "auto", ["auto", "OpenRouter", "OpenAI", "Kobold", "textgenwebui", "Custom"])
     
     @staticmethod
     def get_image_llm_custom_service_url_config_value() -> ConfigValue:
@@ -73,7 +73,7 @@ if you're sending the image and the LLM prompt all at once input 0 , then the va
     
     @staticmethod
     def get_image_llm_custom_token_count_config_value() -> ConfigValue:
-        description = """If the model chosen is not recognised by Mantella, the token count for the given model will default to this number
+        description = """If the model chosen is not recognized by Mantella, the token count for the given model will default to this number
                     If this is not the correct token count for your chosen model, you can change it here
                     Keep in mind that if this number is greater than the actual token count of the model, then Mantella will crash if a given conversation exceeds the model's token limit"""
         return ConfigValueInt("image_llm_custom_token_count","Custom token count",description, 4096, 4096, 9999999,tags=[ConvigValueTag.advanced])

--- a/src/config/definitions/image_llm_definitions.py
+++ b/src/config/definitions/image_llm_definitions.py
@@ -39,11 +39,11 @@ class ImageLLMDefinitions:
 If you're using iterative querying input True (or check the box)
 if you're sending the image and the LLM prompt all at once input False (or uncheck the box) , then the values from [LLM] will be used for image queries except for the prompts
 """
-        return ConfigValueBool("image_analysis_iterative_querying","Use iterative querying",description,False)
+        return ConfigValueBool("image_analysis_iterative_querying","Use iterative querying (two steps image analysis method)",description,False)
  
     @staticmethod
     def get_image_llm_model_config_value() -> ConfigValue:
-        model_description = """ model
+        model_description = """ THIS OPTION WILL ONLY BE TAKEN INTO ACCOUNT IF ITERATIVE QUERYING IS ACTIVATED, IF ITERATIVE QUERYING IS DEACTIVATED THE LLM MODEL WILL BE USED FOR IMAGE ANALYSIS
    Options:
    - OpenRouter: see https://openrouter.ai/docs#models. Take the value displayed under the model heading, the model must be capable of image analysis on an OpenAI compatible endpoint.
    - OpenAI: gpt-4-0125-preview, gpt-4o

--- a/src/config/definitions/prompt_definitions.py
+++ b/src/config/definitions/prompt_definitions.py
@@ -135,3 +135,15 @@ class PromptDefinitions:
         resummarize_prompt = """You are tasked with summarizing the conversation history between {name} (the assistant) and the player (the user) / other characters. These conversations take place in {game}.
                                             Each paragraph represents a conversation at a new point in time. Please summarize these conversations into a single paragraph in {language}."""
         return ConfigValueString("resummarize_prompt","Resummarize Prompt",resummarize_prompt_description,resummarize_prompt,[PromptDefinitions.PromptChecker()])
+    
+    @staticmethod
+    def get_image_llm_direct_prompt_config_value() -> ConfigValue:
+        image_llm_direct_prompt_description = """The prompt used if all the complete context prompt and image are sent all at once""" 
+        image_llm_direct_prompt = """This image is to give context and is from the player's point of view"""
+        return ConfigValueString("image_llm_direct_prompt","Image LLM direct prompt",image_llm_direct_prompt_description,image_llm_direct_prompt,[PromptDefinitions.PromptChecker()])
+    
+    @staticmethod
+    def get_image_llm_iterative_prompt_config_value() -> ConfigValue:
+        image_llm_iterative_prompt_description = """The prompt used if the image and context prompt are sent in sequence""" 
+        image_llm_iterative_prompt = """This image is to give context and is from the player's point of view in the game of Fallout 4. Describe the details visible inside it without mentioning the game. Refer to it as a scene instead of an image."""
+        return ConfigValueString("image_llm_iterative_prompt","Image LLM iterative prompt",image_llm_iterative_prompt_description,image_llm_iterative_prompt,[PromptDefinitions.PromptChecker()])

--- a/src/config/definitions/prompt_definitions.py
+++ b/src/config/definitions/prompt_definitions.py
@@ -145,5 +145,5 @@ class PromptDefinitions:
     @staticmethod
     def get_image_llm_iterative_prompt_config_value() -> ConfigValue:
         image_llm_iterative_prompt_description = """The prompt used if the image and context prompt are sent in sequence""" 
-        image_llm_iterative_prompt = """This image is to give context and is from the player's point of view in the game of Fallout 4. Describe the details visible inside it without mentioning the game. Refer to it as a scene instead of an image."""
-        return ConfigValueString("image_llm_iterative_prompt","Image LLM iterative prompt",image_llm_iterative_prompt_description,image_llm_iterative_prompt,[PromptDefinitions.PromptChecker()])
+        image_llm_iterative_prompt = """This image is to give context and is from the player's point of view in the game of {game}. Describe the details visible inside it without mentioning the game. Refer to it as a scene instead of an image."""
+        return ConfigValueString("image_llm_iterative_prompt","Image LLM iterative (two steps) prompt",image_llm_iterative_prompt_description,image_llm_iterative_prompt,[PromptDefinitions.PromptChecker()])

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -10,6 +10,7 @@ from src.config.definitions.other_definitions import OtherDefinitions
 from src.config.definitions.prompt_definitions import PromptDefinitions
 from src.config.definitions.stt_definitions import STTDefinitions
 from src.config.definitions.tts_definitions import TTSDefinitions
+from src.config.definitions.image_llm_definitions import ImageLLMDefinitions
 import sys
 
 
@@ -55,6 +56,25 @@ class MantellaConfigValueDefinitionsNew:
         llm_category.add_config_value(LLMDefinitions.get_max_tokens_config_value())
         result.add_base_group(llm_category)
 
+        image_llm_category = ConfigValueGroup("Image LLM", "Image Analysis", "Settings for the Image analysis LLM providers and the LLMs themselves.", on_value_change_callback)
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_analysis_skyrim_filepath_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_analysis_skyrim_vr_filepath_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_analysis_fallout4_filepath_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_analysis_fallout4_vr_filepath_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_analysis_iterative_querying_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_model_config_value())
+        image_llm_category.add_config_value(PromptDefinitions.get_image_llm_direct_prompt_config_value())
+        image_llm_category.add_config_value(PromptDefinitions.get_image_llm_iterative_prompt_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_max_response_sentences_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_api_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_custom_service_url_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_custom_token_count_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_temperature_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_top_p_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_stop_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_frequency_penalty_config_value())
+        image_llm_category.add_config_value(ImageLLMDefinitions.get_image_llm_max_tokens_config_value())
+        result.add_base_group(image_llm_category)
         tts_category = ConfigValueGroup("TTS", "Text-to-Speech", "Settings for the TTS methods Mantella supports.", on_value_change_callback)
         tts_category.add_config_value(TTSDefinitions.get_tts_service_config_value())
         tts_category.add_config_value(TTSDefinitions.get_xvasynth_folder_config_value())

--- a/src/games/fallout4.py
+++ b/src/games/fallout4.py
@@ -36,6 +36,15 @@ class fallout4(gameable):
         self.__playback: audio_playback = audio_playback(config)
         self.create_all_voice_folders(self.__config)
         self.__last_played_voiceline: str | None = None
+    
+    def get_image_filepath(self):
+        is_vr = self.__config.game == "Fallout4VR"
+        filepath = (
+            self.__config.image_analysis_fallout4_vr_filepath
+            if is_vr
+            else self.__config.image_analysis_fallout4_filepath
+        )
+        return filepath, is_vr
 
     def create_all_voice_folders(self, config: ConfigLoader):
         all_voice_folders = self.character_df["fallout4_voice_folder"]

--- a/src/games/gameable.py
+++ b/src/games/gameable.py
@@ -87,6 +87,18 @@ class gameable(ABC):
         pass
 
     @abstractmethod
+    def get_image_filepath(self) -> bool:
+        """Checks the game that is running and returns a filepath where the game screenshots are located
+
+        Args:
+            none
+
+        Returns:
+            String: The screenshot filepath for the current loaded game
+        """
+        pass
+
+    @abstractmethod
     def load_unnamed_npc(self, name: str, race: str, gender: int, ingame_voice_model:str) -> dict[str, Any]:
         """Loads a generic NPC if the NPC is not found in the CSV file
 

--- a/src/games/skyrim.py
+++ b/src/games/skyrim.py
@@ -17,6 +17,7 @@ class skyrim(gameable):
 
     def __init__(self, config: ConfigLoader):
         super().__init__(config, 'data/Skyrim/skyrim_characters.csv', "Skyrim")
+        self.__config: ConfigLoader = config
         self.__create_all_voice_folders(config)
 
     def get_image_filepath(self):     

--- a/src/games/skyrim.py
+++ b/src/games/skyrim.py
@@ -19,6 +19,15 @@ class skyrim(gameable):
         super().__init__(config, 'data/Skyrim/skyrim_characters.csv', "Skyrim")
         self.__create_all_voice_folders(config)
 
+    def get_image_filepath(self):     
+        is_vr = self.__config.game == "SkyrimVR"
+        filepath = (
+            self.__config.image_analysis_skyrim_vr_filepath
+            if is_vr
+            else self.__config.image_analysis_skyrim_filepath 
+        )
+        return filepath, is_vr
+
     def __create_all_voice_folders(self, config: ConfigLoader):
         all_voice_folders = self.character_df["skyrim_voice_folder"]
         all_voice_folders = all_voice_folders.loc[all_voice_folders.notna()]

--- a/src/image/image_manager.py
+++ b/src/image/image_manager.py
@@ -9,6 +9,9 @@ from src.conversation.context import context
 from src.llm.message_thread import message_thread
 from pathlib import Path
 from datetime import datetime, timedelta
+import base64
+from PIL import Image
+from io import BytesIO
 
 class ImageToDelete:
     def __init__(self, image_path: Path):
@@ -17,6 +20,7 @@ class ImageToDelete:
 class ImageManager:
     KEY_CONTEXT_CUSTOMVALUES_VISION_READY: str = "mantella_vision_ready"
     KEY_CONTEXT_CUSTOMVALUES_VISION_RES: str = "mantella_vision_resolution"
+    KEY_CONTEXT_CUSTOMVALUES_VISION_RESIZE: int = "mantella_vision_resize"
     def __init__(self, context_for_conversation, output_manager, generation_thread) -> None:
         
         self.__context: context = context_for_conversation 
@@ -34,20 +38,32 @@ class ImageManager:
                 self.__images_to_delete.append(ImageToDelete(path_obj))
                 #logging.info(f"Image {image_path} added to delete list.")
             else:
-                logging.warning(f"The file {image_path} does not exist.")
+                logging.debug(f"The file {image_path} does not exist.")
         except Exception as e:
-            logging.error(f"An error occurred while adding image to delete list: {e}")
+            logging.debug(f"An error occurred while adding image to delete list: {e}")
 
     def delete_images_from_file(self):
         for image in self.__images_to_delete:
             try:
+                # Regular image deletion
                 if image.image_path.is_file():
-                    image.image_path.unlink()  # Delete the file, to enable later
-                    logging.log(21,f"Deleted image {image.image_path}")
+                    image.image_path.unlink()  # Delete the file
+                    logging.debug( f"Deleted image {image.image_path}")
                 else:
-                    logging.warning(f"The file {image.image_path} does not exist.")
+                    logging.debug(f"The file {image.image_path} does not exist.")
+
+                # Prepare the VR image path
+                vr_image_path = image.image_path.with_name(image.image_path.stem + '_vr.jpg')
+                
+                # VR image deletion
+                if vr_image_path.is_file():
+                    vr_image_path.unlink()  # Delete the VR file
+                    logging.debug( f"Deleted VR image {vr_image_path}")
+                else:
+                    logging.debug(f"The VR file {vr_image_path} does not exist.")
             except Exception as e:
-                logging.error(f"An error occurred while deleting image {image.image_path}: {e}")
+                logging.error(f"An error occurred while deleting images: {e}")
+
         # Clear the list after attempting to delete all images
         self.__images_to_delete.clear()
 
@@ -61,6 +77,68 @@ class ImageManager:
             except Exception as e:
                 logging.error(f"An error occurred while adding the latest image to deletion array: {e}")
 
+    @staticmethod
+    def resize_image(image_path, target_width):
+        """
+        Resize the image at the specified path to the target width while preserving the aspect ratio.
+        Parameters:
+        - image_path: Path to the image to be resized.
+        - target_width: Desired width of the image. If None or the original width is smaller, no resizing is performed.
+        """
+        try:
+            with Image.open(image_path) as img:
+                original_width, original_height = img.size
+
+                # If resizing is not needed
+                if target_width is None or original_width <= target_width:
+                    # Save the image temporarily to avoid returning a closed object
+                    img.save(image_path)
+                    # Reopen and return the image as a new PIL Image object
+                    return Image.open(image_path)
+
+                # Calculate new dimensions
+                aspect_ratio = original_height / original_width
+                new_height = int(target_width * aspect_ratio)
+
+                # Resize and return new image
+                resized_img = img.resize((target_width, new_height), Image.LANCZOS )
+                resized_img.save(image_path)  # Overwrite the original image or save as a new file
+                #logging.info(f"Resized image to target width :  {target_width}")
+                return resized_img
+        except Exception as e:
+            logging.warning(f"Failed to resize image {image_path}: {str(e)}")
+            return None
+
+        # Example usage
+        # resized_image = resize_image('path/to/your/image.jpg', 1900)
+        # if resized_image is None:
+        #     print("Image resizing failed.")
+
+    @staticmethod
+    def image_to_base64(pil_img, format='JPEG'):
+        """
+        Convert a PIL Image object to a base64-encoded string.
+        
+        Parameters:
+            pil_img (PIL.Image): A PIL Image object.
+            format (str): The format to save the image in memory. Defaults to 'JPEG'.
+            
+        Returns:
+            str: A base64-encoded string of the image.
+        """
+        # Create a bytes buffer for the in-memory image
+        img_buffer = BytesIO()
+        
+        # Save the image to the buffer in JPEG format
+        pil_img.save(img_buffer, format=format)
+        
+        # Get the byte data from the buffer
+        byte_data = img_buffer.getvalue()
+        
+        # Encode this byte data to base64
+        base64_str = base64.b64encode(byte_data).decode('utf-8')
+        
+        return base64_str
 
     def __create_message_from_image(self,description):
         try:
@@ -79,10 +157,13 @@ class ImageManager:
                 image_path = Path(image_path) / "Mantella_Vision.jpg" 
             # Check if the file exists
             if not image_path.is_file():
-                logging.warning(f"The file {str(image_path)} does not exist.")
+                logging.debug(f"The file {str(image_path)} does not exist.")
                 return None
             resolution = str(self.__context.get_custom_context_value(self.KEY_CONTEXT_CUSTOMVALUES_VISION_RES)).lower() or "auto"
-            image_msg_instance = image_message(str(image_path), description, resolution, True)  # Need to put player name back in eventually
+            resize_value = int(self.__context.get_custom_context_value(self.KEY_CONTEXT_CUSTOMVALUES_VISION_RESIZE)) or 1024
+            image_object = self.resize_image(image_path, resize_value) #Need to make this editable
+            encoded_image_str = self.image_to_base64(image_object)
+            image_msg_instance = image_message(encoded_image_str, description, resolution, True)  # Need to put player name back in eventually
             return image_msg_instance
                    
         except Exception as e:
@@ -96,27 +177,34 @@ class ImageManager:
             messages.delete_all_message_type(image_description_message)
 
     def process_image_analysis(self, messages: message_thread):
-        if self.__context.get_custom_context_value(self.KEY_CONTEXT_CUSTOMVALUES_VISION_READY)==True:
+        if self.__context.get_custom_context_value(self.KEY_CONTEXT_CUSTOMVALUES_VISION_READY):
             if self.__context.config.image_analysis_iterative_querying == False:
-                logging.info("'Vision ready' Returned true, commencing iterative query")
-                image_instance= self.__create_message_from_image(self.__direct_prompt) 
-                messages.replace_or_add_message(image_instance,image_message)
+                logging.info("'Vision ready' Returned true, attempting direct image query")
+                image_instance = self.__create_message_from_image(self.__direct_prompt)
+                if image_instance:
+                    messages.replace_or_add_message(image_instance, image_message)
+                else:
+                    logging.debug("No valid image instance created for direct querying.")
             else:
-                image_instance= self.__create_message_from_image(self.__iterative_prompt)
-                logging.info("Waiting for image_description_response to be filled")
-                self.__generation_thread = Thread(target=self.__output_manager.generate_simple_response, args=[image_instance])
-                self.__generation_thread.start()
-                self.__generation_thread.join()  # Wait for generate_simple_response to complete
-                self.__generation_thread=None
-                new_image_description_message : image_description_message = image_description_message(self.__output_manager.generated_simple_result, False)
-                if self.__output_manager.generated_simple_result != "":
-                    messages.replace_or_add_message(new_image_description_message,image_description_message)
-                self.__output_manager.generated_simple_result=""
-
+                logging.info("'Vision ready' Returned true, attempting iterative query")
+                image_instance = self.__create_message_from_image(self.__iterative_prompt)
+                if image_instance:
+                    logging.info("Waiting for image_description_response to be filled")
+                    self.__generation_thread = Thread(target=self.__output_manager.generate_simple_response, args=[image_instance])
+                    self.__generation_thread.start()
+                    self.__generation_thread.join()
+                    self.__generation_thread = None
+                    if self.__output_manager.generated_simple_result:
+                        new_image_description_message = image_description_message(self.__output_manager.generated_simple_result, False)
+                        messages.replace_or_add_message(new_image_description_message, image_description_message)
+                    else:
+                        logging.warning("Generated simple response did not produce a valid result.")
+                else:
+                    logging.debug("No valid image instance created for iterative querying.")
         else:
             self.__clean_message_thread_from_images(messages)
 
-    def find_most_recent_jpg(self,directory):
+    def find_most_recent_jpg(self, directory):
         # Convert the directory to a Path object
         time.sleep(0.5)
         dir_path = Path(directory)
@@ -136,18 +224,21 @@ class ImageManager:
             # Filter the files to include only those modified in the last 2 minutes
             recent_files = [f for f in jpg_files if datetime.fromtimestamp(f.stat().st_mtime) > now - timedelta(minutes=2)]
             
-            # Check if there are any recent .jpg files
-            if not recent_files:
-                logging.warning(f"No .jpg files found in the directory {directory} within the last 2 minutes.")
-                return None
-            
-            # Find the most recent .jpg file from the filtered list
-            most_recent_file = max(recent_files, key=lambda f: f.stat().st_mtime)
-            
-            # Return the filepath of the most recent .jpg file
-            logging.log(21,f"Returning most recent Steam jpg file {most_recent_file}.")
-            return str(most_recent_file)
+            # Sort files by modification time, most recent first
+            recent_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
+
+            # Filter out the files based on conditions
+            for file in recent_files:
+                # Check if file ends with '_vr.jpg'
+                if not file.name.endswith('_vr.jpg'):
+                    # Check if file is in the deletion list
+                    if file not in (x.image_path for x in self.__images_to_delete):
+                        logging.debug( f"Returning most recent jpg file {file}.")
+                        return str(file)
+
+            # If no suitable file found
+            logging.debug(f"No suitable .jpg file found in the directory {directory}.")
+            return None
         except Exception as e:
             logging.error(f"Error checking most recent jpg: {e}")
             return None
-    

--- a/src/image/image_manager.py
+++ b/src/image/image_manager.py
@@ -109,7 +109,7 @@ class ImageManager:
                 self.__generation_thread.join()  # Wait for generate_simple_response to complete
                 self.__generation_thread=None
                 new_image_description_message : image_description_message = image_description_message(self.__output_manager.generated_simple_result, False)
-                if self.__output_manager.generated_simple_result is not "":
+                if self.__output_manager.generated_simple_result != "":
                     messages.replace_or_add_message(new_image_description_message,image_description_message)
                 self.__output_manager.generated_simple_result=""
 

--- a/src/image/image_manager.py
+++ b/src/image/image_manager.py
@@ -187,7 +187,10 @@ class ImageManager:
                     logging.debug("No valid image instance created for direct querying.")
             else:
                 logging.info("'Vision ready' Returned true, attempting iterative query")
-                image_instance = self.__create_message_from_image(self.__iterative_prompt)
+                iterative_prompt_instance= self.__iterative_prompt.format(
+                        game=self.__context.config.game
+                    )
+                image_instance = self.__create_message_from_image(iterative_prompt_instance)
                 if image_instance:
                     logging.info("Waiting for image_description_response to be filled")
                     self.__generation_thread = Thread(target=self.__output_manager.generate_simple_response, args=[image_instance])

--- a/src/image/image_manager.py
+++ b/src/image/image_manager.py
@@ -1,0 +1,153 @@
+
+import logging
+import time
+import os
+from threading import Thread
+from src.output_manager import ChatManager
+from src.llm.messages import image_message, image_description_message 
+from src.conversation.context import context
+from src.llm.message_thread import message_thread
+from pathlib import Path
+from datetime import datetime, timedelta
+
+class ImageToDelete:
+    def __init__(self, image_path: Path):
+        self.image_path = image_path
+
+class ImageManager:
+    KEY_CONTEXT_CUSTOMVALUES_VISION_READY: str = "mantella_vision_ready"
+    KEY_CONTEXT_CUSTOMVALUES_VISION_RES: str = "mantella_vision_resolution"
+    def __init__(self, context_for_conversation, output_manager, generation_thread) -> None:
+        
+        self.__context: context = context_for_conversation 
+        self.__output_manager: ChatManager = output_manager
+        #self.__game = self.__output_manager.__game #Check if this is working correctly
+        self.__direct_prompt =self.__context.config.image_llm_direct_prompt
+        self.__iterative_prompt =self.__context.config.image_llm_iterative_prompt
+        self.__generation_thread = generation_thread  # Ensure this is always initialized
+        self.__images_to_delete = []  # Initialize as an empty list of ImageToDelete objects
+
+    def __add_image_to_delete(self, image_path: str):
+        try:
+            path_obj = Path(image_path)
+            if path_obj.is_file():
+                self.__images_to_delete.append(ImageToDelete(path_obj))
+                #logging.info(f"Image {image_path} added to delete list.")
+            else:
+                logging.warning(f"The file {image_path} does not exist.")
+        except Exception as e:
+            logging.error(f"An error occurred while adding image to delete list: {e}")
+
+    def delete_images_from_file(self):
+        for image in self.__images_to_delete:
+            try:
+                if image.image_path.is_file():
+                    image.image_path.unlink()  # Delete the file, to enable later
+                    logging.log(21,f"Deleted image {image.image_path}")
+                else:
+                    logging.warning(f"The file {image.image_path} does not exist.")
+            except Exception as e:
+                logging.error(f"An error occurred while deleting image {image.image_path}: {e}")
+        # Clear the list after attempting to delete all images
+        self.__images_to_delete.clear()
+
+    def attempt_to_add_most_recent_image_to_deletion_array(self):
+        if self.__context.get_custom_context_value(self.KEY_CONTEXT_CUSTOMVALUES_VISION_READY)==True:
+            try:
+                most_recent_image_path, is_vr = self.__output_manager.get_image_filepath()
+                if is_vr: 
+                    most_recent_image_path = self.find_most_recent_jpg(str(most_recent_image_path))
+                    self.__add_image_to_delete(str(most_recent_image_path))
+            except Exception as e:
+                logging.error(f"An error occurred while adding the latest image to deletion array: {e}")
+
+
+    def __create_message_from_image(self,description):
+        try:
+            # Create an instance of the image_message class
+            image_path, is_vr = self.__output_manager.get_image_filepath()
+            image_path = Path(image_path) 
+            if is_vr: 
+                recent_image_path = self.find_most_recent_jpg(str(image_path))
+                if recent_image_path:
+                    image_path = Path(recent_image_path) 
+                else:
+                    logging.warning(f"No jpg file created in the last 2 minutes was found in {str(image_path)} .")
+                    return None
+                self.__add_image_to_delete(str(image_path))
+            else:
+                image_path = Path(image_path) / "Mantella_Vision.jpg" 
+            # Check if the file exists
+            if not image_path.is_file():
+                logging.warning(f"The file {str(image_path)} does not exist.")
+                return None
+            resolution = str(self.__context.get_custom_context_value(self.KEY_CONTEXT_CUSTOMVALUES_VISION_RES)).lower() or "auto"
+            image_msg_instance = image_message(str(image_path), description, resolution, True)  # Need to put player name back in eventually
+            return image_msg_instance
+                   
+        except Exception as e:
+            logging.error(f"An error occurred while creating the user image: {e}")
+            return None
+    
+    def __clean_message_thread_from_images(self, messages):
+        if messages.has_message_type(image_message):
+                messages.delete_all_message_type(image_message)
+        if messages.has_message_type(image_description_message):
+            messages.delete_all_message_type(image_description_message)
+
+    def process_image_analysis(self, messages: message_thread):
+        if self.__context.get_custom_context_value(self.KEY_CONTEXT_CUSTOMVALUES_VISION_READY)==True:
+            if self.__context.config.image_analysis_iterative_querying == False:
+                logging.info("'Vision ready' Returned true, commencing iterative query")
+                image_instance= self.__create_message_from_image(self.__direct_prompt) 
+                messages.replace_or_add_message(image_instance,image_message)
+            else:
+                image_instance= self.__create_message_from_image(self.__iterative_prompt)
+                logging.info("Waiting for image_description_response to be filled")
+                self.__generation_thread = Thread(target=self.__output_manager.generate_simple_response, args=[image_instance])
+                self.__generation_thread.start()
+                self.__generation_thread.join()  # Wait for generate_simple_response to complete
+                self.__generation_thread=None
+                new_image_description_message : image_description_message = image_description_message(self.__output_manager.generated_simple_result, False)
+                if self.__output_manager.generated_simple_result is not "":
+                    messages.replace_or_add_message(new_image_description_message,image_description_message)
+                self.__output_manager.generated_simple_result=""
+
+        else:
+            self.__clean_message_thread_from_images(messages)
+
+    def find_most_recent_jpg(self,directory):
+        # Convert the directory to a Path object
+        time.sleep(0.5)
+        dir_path = Path(directory)
+        
+        # Check if the directory exists
+        if not dir_path.is_dir():
+            logging.error(f"The directory {directory} for image search does not exist or is not a directory.")
+            return None
+        
+        try:
+            # Get the current time
+            now = datetime.now()
+            
+            # Get a list of all .jpg files in the directory
+            jpg_files = list(dir_path.glob('*.jpg'))
+            
+            # Filter the files to include only those modified in the last 2 minutes
+            recent_files = [f for f in jpg_files if datetime.fromtimestamp(f.stat().st_mtime) > now - timedelta(minutes=2)]
+            
+            # Check if there are any recent .jpg files
+            if not recent_files:
+                logging.warning(f"No .jpg files found in the directory {directory} within the last 2 minutes.")
+                return None
+            
+            # Find the most recent .jpg file from the filtered list
+            most_recent_file = max(recent_files, key=lambda f: f.stat().st_mtime)
+            
+            # Return the filepath of the most recent .jpg file
+            logging.log(21,f"Returning most recent Steam jpg file {most_recent_file}.")
+            return str(most_recent_file)
+        except Exception as e:
+            logging.error(f"Error checking most recent jpg: {e}")
+            return None
+    

--- a/src/llm/messages.py
+++ b/src/llm/messages.py
@@ -3,8 +3,6 @@ from openai.types.chat import ChatCompletionMessageParam
 from src.character_manager import Character
 
 from src.llm.sentence import sentence
-import base64
-import logging
 
 class message(ABC):
     """Base class for messages 
@@ -151,26 +149,17 @@ class user_message(message):
 class image_message(message):
     """A image message sent to the LLM. Contains the a base64 encode image and accompanying description text.
     """
-    def __init__(self, image_path: str, text: str = "", resolution: str = "auto", is_system_generated_message: bool = False):
+    def __init__(self, encoded_image: str, text: str = "", resolution: str = "auto", is_system_generated_message: bool = False):
         super().__init__(text, is_system_generated_message)
-        self.image_path = image_path
+        self.encoded_image = encoded_image
         self.text_content = text
         self.resolution = resolution
 
     def get_formatted_content(self):
-        return f"[Image: {self.image_path}] {self.text_content}"
+        return f"[Image: {self.encoded_image}] {self.text_content}"
 
     def get_dict_formatted_string(self):
-        return f"Image: {self.image_path}, Content: {self.text_content}"
-
-    @staticmethod
-    def encode_image_to_base64(image_path):
-        try:
-            with open(image_path, "rb") as image_file:
-                return base64.b64encode(image_file.read()).decode('utf-8')
-        except Exception as e:
-            logging.error(f"Error encoding image to base64: {e}")
-            return None
+        return f"Image: {self.encoded_image}, Content: {self.text_content}"
 
     def get_openai_message(self):
         # Implement the method to return the appropriate format for OpenAI API
@@ -184,7 +173,7 @@ class image_message(message):
                 {
                     "type": "image_url",
                     "image_url": {
-                        "url": f"data:image/jpeg;base64,{self.encode_image_to_base64(self.image_path)}",
+                        "url": f"data:image/jpeg;base64,{self.encoded_image}",
                         "detail": self.resolution
                     }
                 }

--- a/src/llm/messages.py
+++ b/src/llm/messages.py
@@ -3,6 +3,8 @@ from openai.types.chat import ChatCompletionMessageParam
 from src.character_manager import Character
 
 from src.llm.sentence import sentence
+import base64
+import logging
 
 class message(ABC):
     """Base class for messages 
@@ -144,3 +146,72 @@ class user_message(message):
     
     def set_ingame_time(self, time: str, time_group: str):
         self.__time = time, time_group
+
+
+class image_message(message):
+    """A image message sent to the LLM. Contains the a base64 encode image and accompanying description text.
+    """
+    def __init__(self, image_path: str, text: str = "", resolution: str = "auto", is_system_generated_message: bool = False):
+        super().__init__(text, is_system_generated_message)
+        self.image_path = image_path
+        self.text_content = text
+        self.resolution = resolution
+
+    def get_formatted_content(self):
+        return f"[Image: {self.image_path}] {self.text_content}"
+
+    def get_dict_formatted_string(self):
+        return f"Image: {self.image_path}, Content: {self.text_content}"
+
+    @staticmethod
+    def encode_image_to_base64(image_path):
+        try:
+            with open(image_path, "rb") as image_file:
+                return base64.b64encode(image_file.read()).decode('utf-8')
+        except Exception as e:
+            logging.error(f"Error encoding image to base64: {e}")
+            return None
+
+    def get_openai_message(self):
+        # Implement the method to return the appropriate format for OpenAI API
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": self.text_content
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{self.encode_image_to_base64(self.image_path)}",
+                        "detail": self.resolution
+                    }
+                }
+            ]
+        }
+    
+class image_description_message(message):
+    """An image description message, similar to a user message but interacted with by the conversation object"""
+    def __init__(self, text: str = "", is_system_generated_message: bool = False):
+        super().__init__(text, is_system_generated_message)
+        self.text_content = text
+
+    def get_formatted_content(self):
+        return self.Text
+
+    def get_dict_formatted_string(self):
+        dictionary = {"role":"user", "content": self.get_formatted_content(),}
+        return f"{dictionary}"
+
+    def get_openai_message(self):
+        # Implement the method to return the appropriate format for OpenAI API
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"This is description of the scene is only to give context to the conversation and is from the point of view of the player: {self.text_content}"
+                }
+            ]
+        }

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -13,13 +13,13 @@ from src.llm.sentence import sentence as mantella_sentence #<- Do not collide wi
 import src.utils as utils
 from src.characters_manager import Characters
 from src.character_manager import Character
-from src.llm.messages import message
+from src.llm.messages import message, image_message
 from src.llm.message_thread import message_thread
-from src.llm.openai_client import openai_client
+from src.llm.openai_client import openai_client, image_client  
 from src.tts.ttsable import ttsable
 
 class ChatManager:
-    def __init__(self, game: gameable, config: ConfigLoader, tts: ttsable, client: openai_client):
+    def __init__(self, game: gameable, config: ConfigLoader, tts: ttsable, client: openai_client, image_client_instance: image_client):
         self.loglevel = 28
         self.__game: gameable = game
         self.max_response_sentences = config.max_response_sentences
@@ -27,12 +27,25 @@ class ChatManager:
         self.wait_time_buffer = config.wait_time_buffer
         self.__tts: ttsable = tts
         self.__client: openai_client = client
+        self.__image_client: image_client = image_client_instance 
         self.__is_generating: bool = False
         self.__stop_generation: bool = False
         self.__tts_access_lock = Lock()
         self.__number_words_tts: int = config.number_words_tts
         self.__end_of_sentence_chars = ['.', '?', '!', ':', ';']
         self.__end_of_sentence_chars = [unicodedata.normalize('NFKC', char) for char in self.__end_of_sentence_chars]
+        self.__generated_simple_result_lock = Lock()
+        self.__generated_simple_result = ""
+
+    @property
+    def generated_simple_result(self):
+        with self.__generated_simple_result_lock:
+            return self.__generated_simple_result
+
+    @generated_simple_result.setter
+    def generated_simple_result(self, value):
+        with self.__generated_simple_result_lock:
+            self.__generated_simple_result = value
 
     def generate_sentence(self, text: str, character_to_talk: Character, is_system_generated_sentence: bool = False) -> mantella_sentence:
         """Generates the audio for a text and returns the corresponding sentence
@@ -326,3 +339,62 @@ class ChatManager:
             # before the ChatManager realises there is not another message coming from the LLM
             blocking_queue.put(mantella_sentence(active_character,"","",0, True))
             self.__is_generating = False
+
+
+    def generate_simple_response(self, message):
+            #Generates a response for a single message without characters or actions.
+            self.__is_generating = True
+            self.run_async(self.process_simple_response(message))
+                
+    async def process_simple_response(self, message):
+        """Stream response from LLM for a single message."""
+        logging.info("Starting process simple response")
+        try:
+            sentence = ''
+            full_reply = ''
+            if isinstance(message, image_message):
+                response_client = self.__image_client
+            else:
+                response_client = self.__client
+            while True:
+                try:
+                    start_time = time.time()
+                    async for content in response_client.streaming_one_message_call(message):
+                        if self.__stop_generation:
+                            break
+                        if not content:
+                            continue
+
+                        sentence += content
+
+                    break
+                except Exception as e:
+                    if isinstance(message, image_message):
+                        logging.error(f"Image LLM API Error: {e}")
+                    else:
+                        logging.error(f"LLM API Error: {e}")
+                    logging.log(self.loglevel, 'Retrying connection to API...')
+                    time.sleep(5)
+
+            full_reply += sentence
+            logging.log(self.loglevel, f"LLM returned simple response took {time.time() - start_time} seconds to execute")
+
+        except Exception as e:
+            logging.error(f"LLM API Error: {e}")
+        finally:
+            logging.log(22, f"Simple response saved ({response_client.calculate_tokens_from_text(full_reply)} tokens): {full_reply}")
+            self.__is_generating = False
+            self.generated_simple_result=full_reply
+    
+    def run_async(self, coro):
+        try:
+            logging.info("Try to get running loop to create task")
+            loop = asyncio.get_running_loop()
+            return loop.create_task(coro)
+        except RuntimeError:
+            logging.info("RunTimeError, trying to asyncio.run(coro)")
+            return asyncio.run(coro)
+        
+    def get_image_filepath(self):
+        return self.__game.get_image_filepath()
+        


### PR DESCRIPTION
**This PR makes multiple changes to Mantella to allow image analysis.** 
The aim was to allow two things : 

1. Direct analyses of image through a LLM ( for now I only had success with ChatGPT4-o) where the image is sent alongside the whole prompt.
2. Two step iterative queries where an image analysis LLM is used then another LLM (or the same one if desired) is used to process the classic Mantella prompt. This allows to avoid relying on ChatGPt4-o or it allows to only rely on it for image analysis and not the actual NPC responses.

### Key points:

1. Adds a requirement for a new IMAGE_GPT_SECRET_KEY.txt that should hold a key to the image analysis service (may be left empty for local analysis but the file has to be there).
2. Adds new variables to configloader and definitions to allow to set file path for screenshots (need to be game root directory for SK and FO4 desktop and steam directory for SK and FO4 VR), it also allows to choose image LLM models, service (openAI, openrouter, local) and specs (temperature, etc).
3. New prompts definitions are added for image prompts both direct and iterative (two steps)
4. Conversation.py now creates a image manager at the start of the conversation and ask it to process_image_analysis if the conversation isn't over. If the conversation is over it will attempt to clean all the files in it's deletion array.
5. New abstract methods for the gameable Skyrim and FO4 to get the the filepath for the images.
6. Mantellaroute.py now loads a secret_key_file for the image manager and generates an image client will all the config specs at the start of Mantella (image client is only used in the iterative two steps method of image analysis)
7. OpenAI client was refactored to accomodate a new class : image_client that class stores all the info for the image LLM use in the iterative two step method and has it's own specific method for steaming calls : streaming_one_message_call()
8. Outputmanager.py has a new property 'generated_simple_result' that store the feedback of the image_LLM as well as three new methods to make one message calls to the image LLM : generate_simple_response(), process_simple_response(), run_async(). Also a new method get_image_filepath is used to pull the appropriate filepath from the gameable.
9. Message_thread.py has a couple new method to check, delete or replace messages of a specific type. **Image placement in the message_thread is very finicky from my experience. It's better to have it as close to the end of the message_thread as possible and only have one image or image description present to make sure the LLM is taking it into account.**
10. Messages.py has two new subclasses : image_message that contains image only messages and image_description_message that contains the text received from the image LLM in the two step method.
11. New image manager script, see below

**The new image manager.py handles multiple tasks:**

1. **Runs process_image_analysis() :** Main workhorse of the image_manager, this checks the context values to see if a screenshot is ready to analyze and will attempt to process it according to the option selected in iterative query in the config. If iterative query is disabled it will attempt to send the image directly to the LLM along with the rest of the prompt. If iterative query is enabled it will instead send a request to the image_client and once it gets the response back it will create a new image description message in the message_thread.       If no image is ready it removes all encoded images and image descriptions from the message thread to avoid overloading the LLM. It also insures that there's only one image or only one image description present at any time in the message_thread to avoid overloading the LLM with info (from my testing event ChatGPT4-o gets confused when multiple images are in the thread). 
2. The creation of image messages (contain the base64 encoded images)
3. The  creation of image description messages (contain the feedback from the image LLM to send to the default LLM in the iterative two steps method). 
4. Handles the tracking of the Steam screenshots (VR only) 
5. Handles he encoding of the image to base64
6. Finds the most recent appropriate one within the last two minutes of gameplay (VR only) 
7. It resizes of the image according to the game's feedback
8. Once the conversation is done it will remove the analyzed screenshots from the Steam folder (VR only), The steam folder management for screenshots is for VR only, for desktop the screenshots are stored in the game folder in a much more straightforward manner and are not deleted instead it's the same one that keeps being overwritten as gameplay progresses.

### Potential future upgrades : 

1. Cell scan for NPC lists, distance checks and cell name to give hints to the LLM to the location and actors where the screenshot is taken
2. Make the file deletion optional for screenshots in Steam
3. For Skyrim VR : Take the screenshot directly without having the user have to activate the screenshot using the steam overlay hotkey. This would require SKSE.
4. For Fallout 4 VR, not having to rely on the SUP_F4SE Steam overlay functions for screenshots. This would require making our own in F4SE.
5. Modify the prompts and message again so that it takes into account the player name according to the config.
6. Prompts could be reworked a bit too to help the LLM analyse more clearly
7.  I found that asking some LLMs too much image analysis makes them fall into "tour guide mode" where's that's all they care about. Maybe there's a way to autocorrect that issue.