### PR TITLE
Fixed character stats not updated as conversation continues

### DIFF
--- a/src/character_manager.py
+++ b/src/character_manager.py
@@ -153,6 +153,14 @@ class Character:
     def voice_accent(self, value: str):
         self.__voice_accent = value
 
+    @property
+    def custom_character_values(self) -> dict[str, Any]:
+        return self.__custom_character_values
+    
+    @custom_character_values.setter
+    def custom_character_values(self, value: dict[str, Any]):
+        self.__custom_character_values = value
+
     def get_custom_character_value(self, key: str) -> Any:
         if self.__custom_character_values.__contains__(key):
             return self.__custom_character_values[key]

--- a/src/characters_manager.py
+++ b/src/characters_manager.py
@@ -24,12 +24,18 @@ class Characters:
     def active_character_count(self):
         return len(self.__active_characters)
     
-    def add_character(self, new_character: Character):
-        if not self.__active_characters.__contains__(new_character.name):
-            self.__active_characters[new_character.name] = new_character            
+    def add_or_update_character(self, new_character: Character):
+        if not self.__active_characters.__contains__(new_character.name): #Is add
+            self.__active_characters[new_character.name] = new_character   
             if new_character.is_player_character:
                 self.__player_character = new_character
             else:
+                self.__last_added_character = new_character
+        else: #Is update
+            self.__active_characters[new_character.name] = new_character   
+            if new_character.is_player_character:
+                self.__player_character = new_character
+            elif self.__last_added_character and self.__last_added_character.name == new_character.name:
                 self.__last_added_character = new_character
     
     def remove_character(self, character_to_remove: Character):
@@ -41,7 +47,7 @@ class Characters:
                 for (name, character) in self.__active_characters.items():
                     if not character.is_player_character:
                         self.__last_added_character = character
-
+    
     def get_character_by_name(self, name: str) -> Character:
         return self.__active_characters[name]
         

--- a/src/characters_manager.py
+++ b/src/characters_manager.py
@@ -31,12 +31,11 @@ class Characters:
                 self.__player_character = new_character
             else:
                 self.__last_added_character = new_character
-        else: #Is update
-            self.__active_characters[new_character.name] = new_character   
-            if new_character.is_player_character:
-                self.__player_character = new_character
-            elif self.__last_added_character and self.__last_added_character.name == new_character.name:
-                self.__last_added_character = new_character
+        else: #Is update: update transient stats + custom values
+            self.__active_characters[new_character.name].is_enemy = new_character.is_enemy
+            self.__active_characters[new_character.name].is_in_combat = new_character.is_in_combat
+            self.__active_characters[new_character.name].relationship_rank = new_character.relationship_rank
+            self.__active_characters[new_character.name].custom_character_values = new_character.custom_character_values
     
     def remove_character(self, character_to_remove: Character):
         if self.__active_characters.__contains__(character_to_remove.name):

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -85,12 +85,13 @@ class context:
     def add_or_update_characters(self, new_list_of_npcs: list[Character]):
         for npc in new_list_of_npcs:
             if not self.__npcs_in_conversation.contains_character(npc):
-                self.__npcs_in_conversation.add_character(npc)
+                self.__npcs_in_conversation.add_or_update_character(npc)
                 #self.__ingame_events.append(f"{npc.name} has joined the conversation")
                 self.__have_actors_changed = True
             else:
                 #check for updates in the transient stats and generate update events
                 self.__update_ingame_events_on_npc_change(npc)
+                self.__npcs_in_conversation.add_or_update_character(npc)
         for npc in self.__npcs_in_conversation.get_all_characters():
             if not npc in new_list_of_npcs:
                 self.__remove_character(npc)
@@ -296,5 +297,5 @@ class context:
         new_characters = Characters()
         for actor in self.__npcs_in_conversation.get_all_characters():
             if not actor.is_player_character:
-                new_characters.add_character(actor)
+                new_characters.add_or_update_character(actor)
         return new_characters


### PR DESCRIPTION
Fixed changes in the transient states of an NPC (`is_in_combat`, `is_enemy`, `relationship_rank`, `custom_character_values`) not being updated.
The change event message was generated but the `character` instance was not actually updated.