### PR TITLE
Fallout-specific changes allowing game to handle audio, lip-sync and subtitles natively

### DIFF
--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -271,7 +271,7 @@ class context:
         """
         equipment_descriptions = []
         for character in self.get_characters_excluding_player().get_all_characters():
-                equipment_descriptions.append(character.equipment.get_equipment_description(character.name))
+                equipment_descriptions.append(character.equipment().get_equipment_description(character.name))
         return " ".join(equipment_descriptions)
     
     def generate_system_message(self, prompt: str) -> str:
@@ -290,7 +290,7 @@ class context:
         player_equipment = ""
         if player:
             player_name = player.name
-            player_equipment = player.equipment.get_equipment_description(player_name)
+            player_equipment = player.equipment().get_equipment_description(player_name)
             game_sent_description = player.get_custom_character_value(communication_constants.KEY_ACTOR_PC_DESCRIPTION)
             if game_sent_description and game_sent_description != "":
                 player_description = game_sent_description

--- a/src/utils.py
+++ b/src/utils.py
@@ -22,7 +22,7 @@ def clean_text(text):
     # Remove all punctuation from the sentence
     text_cleaned = text.translate(str.maketrans('', '', string.punctuation))
     # Remove any extra whitespace
-    text_cleaned = re.sub('\s+', ' ', text_cleaned).strip()
+    text_cleaned = re.sub('\\s+', ' ', text_cleaned).strip()
     text_cleaned = text_cleaned.lower()
 
     return text_cleaned


### PR DESCRIPTION
Fallout-specific changes allowing game to handle audio, lip-sync and subtitles natively
Fixed typos
-Added missing parentheses to player.equipment() in context.py
-Added missing '\' to regex in utils.py
Fallout specific:
 - Compatibility for new method of playing audio, lip-sync and subtitles
 - Added copying of wav and lip files to new Mantella-specific voice directories
 - Eliminated all code for fallout-specific playing audio, game is doing it now.
 - Eliminated code to create all voice directories, only 8 needed now.