### PR TITLE
Replaced resize image option with low resolution mode

### DIFF
--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -256,9 +256,9 @@ class ConfigLoader:
 
             # Vision
             self.vision_enabled = self.__definitions.get_bool_value('vision_enabled')
+            self.low_resolution_mode = self.__definitions.get_bool_value("low_resolution_mode")
             self.save_screenshot = self.__definitions.get_bool_value('save_screenshot')
             self.image_quality = self.__definitions.get_int_value("image_quality")
-            self.resize_image = self.__definitions.get_bool_value("resize_image")
             self.resize_method = self.__definitions.get_string_value("resize_method")
             self.capture_offset = json.loads(self.__definitions.get_string_value("capture_offset"))
             

--- a/src/config/definitions/vision_definitions.py
+++ b/src/config/definitions/vision_definitions.py
@@ -11,20 +11,20 @@ class VisionDefinitions:
         return ConfigValueBool("vision_enabled", "Vision", "If enabled, in-game screenshots are passed to the chosen LLM with each player response. This feature is only compatible with LLMs that accept image as well as text inputs.", False)
     
     @staticmethod
+    def get_low_resolution_mode_config_value() -> ConfigValue:
+        return ConfigValueBool("low_resolution_mode", "Low Resolution Mode", "Resizes the image to 512x512 pixels (cropping the edges of the longest side). Enable this setting to lower API costs and improve performance.", True)
+    
+    @staticmethod
     def get_save_screenshot_config_value() -> ConfigValue:
-        return ConfigValueBool("save_screenshot", "Save Screenshots", "Whether to save screenshots to Documents/My Games/Mantella/data/tmp/images/. Disable this setting to improve performance.", False)
+        return ConfigValueBool("save_screenshot", "Save Screenshots", "Whether to save screenshots to Documents/My Games/Mantella/data/tmp/images/. Disable this setting to improve performance.", True)  
 
     @staticmethod
     def get_image_quality_config_value() -> ConfigValue:
-        return ConfigValueInt("image_quality", "Screenshot Quality", "The quality of the image passed to the LLM from 1-100. Higher values improve the LLM's understanding of passed images. Lower values improve performance.", 50, 1, 100, tags=[ConvigValueTag.advanced])
-    
-    @staticmethod
-    def get_resize_image_config_value() -> ConfigValue:
-        return ConfigValueBool("resize_image", "Resize Image", "Resize image to a height of 512 pixels. Enable this setting to lower API costs / improve performance.", True, tags=[ConvigValueTag.advanced])
+        return ConfigValueInt("image_quality", "Screenshot Quality", "The quality of the image passed to the LLM from 1-100. Higher values improve the LLM's understanding of passed images. Lower values slightly improve performance. This setting has no affect on API costs.", 50, 1, 100, tags=[ConvigValueTag.advanced])
 
     @staticmethod
     def get_resize_method_config_value() -> ConfigValue:
-        return ConfigValueSelection("resize_method", "Resize Method", "The image scaling algorithm used to resize in-game screenshots if Resize Image is enabled. Algorithms are sorted from fastest / lowest quality (Nearest) to slowest / highest quality (Lanczos).", "Nearest", ["Nearest", "Linear", "Cubic", "Lanczos"], tags=[ConvigValueTag.advanced])
+        return ConfigValueSelection("resize_method", "Resize Method", "The image scaling algorithm used to resize in-game screenshots to match the target resolution. Algorithms are sorted from fastest / lowest quality (Nearest) to slowest / highest quality (Lanczos).", "Nearest", ["Nearest", "Linear", "Cubic", "Lanczos"], tags=[ConvigValueTag.advanced])
     
     @staticmethod
     def get_capture_offset_config_value() -> ConfigValue:

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -95,9 +95,9 @@ class MantellaConfigValueDefinitionsNew:
 
         vision_category = ConfigValueGroup("Vision", "Vision", "Vision settings.", on_value_change_callback)
         vision_category.add_config_value(VisionDefinitions.get_vision_enabled_config_value())
+        vision_category.add_config_value(VisionDefinitions.get_low_resolution_mode_config_value())
         vision_category.add_config_value(VisionDefinitions.get_save_screenshot_config_value())
         vision_category.add_config_value(VisionDefinitions.get_image_quality_config_value())
-        vision_category.add_config_value(VisionDefinitions.get_resize_image_config_value())
         vision_category.add_config_value(VisionDefinitions.get_resize_method_config_value())
         vision_category.add_config_value(VisionDefinitions.get_capture_offset_config_value())
         result.add_base_group(vision_category)

--- a/src/llm/openai_client.py
+++ b/src/llm/openai_client.py
@@ -137,7 +137,7 @@ For more information, see here:
                                                 config.save_folder, 
                                                 config.save_screenshot, 
                                                 config.image_quality, 
-                                                config.resize_image, 
+                                                config.low_resolution_mode, 
                                                 config.resize_method, 
                                                 config.capture_offset)
     


### PR DESCRIPTION
Removed the UI option to resize / not resize captured images in favour of following the resolution guidelines outlined here:
https://platform.openai.com/docs/guides/vision/managing-images