### PR TITLE
Added max count events, changed reload to use token count

### DIFF
--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -238,6 +238,7 @@ class ConfigLoader:
 
             #Conversation
             self.automatic_greeting = self.__definitions.get_bool_value("automatic_greeting")
+            self.max_count_events = self.__definitions.get_int_value("max_count_events")
             self.player_character_description: str = self.__definitions.get_string_value("player_character_description")
             self.voice_player_input: bool = self.__definitions.get_bool_value("voice_player_input")
             self.player_voice_model: str = self.__definitions.get_string_value("player_voice_model")

--- a/src/config/definitions/other_definitions.py
+++ b/src/config/definitions/other_definitions.py
@@ -24,6 +24,13 @@ class OtherDefinitions:
                                         - If disabled: The LLM will not respond until the player speaks first."""
         return ConfigValueBool("automatic_greeting","Automatic Greeting",automatic_greeting_description,True)
     
+    @staticmethod
+    def get_max_count_events_config_value() -> ConfigValue:
+        max_count_events_description = """Maximum number of ingame events that can are sent to the LLM with one message of the user. 
+                                    If the maximum number is reached, the oldest event will be dropped.
+                                    Increasing this number will cost more prompt tokens and might require a larger context size quickly."""
+        return ConfigValueInt("max_count_events","Max Count Events",max_count_events_description,5,0,999999)
+    
     #Player Character
     @staticmethod
     def get_player_character_description() -> ConfigValue:

--- a/src/config/definitions/other_definitions.py
+++ b/src/config/definitions/other_definitions.py
@@ -26,9 +26,9 @@ class OtherDefinitions:
     
     @staticmethod
     def get_max_count_events_config_value() -> ConfigValue:
-        max_count_events_description = """Maximum number of ingame events that can are sent to the LLM with one message of the user. 
-                                    If the maximum number is reached, the oldest event will be dropped.
-                                    Increasing this number will cost more prompt tokens and might require a larger context size quickly."""
+        max_count_events_description = """Maximum number of in-game events that can are sent to the LLM with one player message. 
+                                    If the maximum number is reached, the oldest events will be dropped.
+                                    Increasing this number will cost more prompt tokens and lead to the context limit being reached faster."""
         return ConfigValueInt("max_count_events","Max Count Events",max_count_events_description,5,0,999999)
     
     #Player Character

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -120,6 +120,7 @@ class MantellaConfigValueDefinitionsNew:
         other_category.add_config_value(OtherDefinitions.get_show_http_debug_messages_config_value())
         other_category.add_config_value(OtherDefinitions.get_remove_mei_folders_config_value())
         other_category.add_config_value(OtherDefinitions.get_automatic_greeting_config_value())
+        other_category.add_config_value(OtherDefinitions.get_max_count_events_config_value())
         other_category.add_config_value(OtherDefinitions.get_player_character_description())
         other_category.add_config_value(OtherDefinitions.get_voice_player_input())
         other_category.add_config_value(OtherDefinitions.get_player_voice_model())

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -48,7 +48,7 @@ class GameStateManager:
             world_id = input_json[comm_consts.KEY_STARTCONVERSATION_WORLDID]
             world_id = self.WORLD_ID_CLEANSE_REGEX.sub("", world_id)
         context_for_conversation = context(world_id, self.__config, self.__client, self.__rememberer, self.__language_info, self.__client.is_text_too_long)
-        self.__talk = conversation(context_for_conversation, self.__chat_manager, self.__rememberer, self.__client.are_messages_too_long, self.__actions)
+        self.__talk = conversation(context_for_conversation, self.__chat_manager, self.__rememberer, self.__client, self.__actions)
         self.__update_context(input_json)
         self.__talk.start_conversation()
         


### PR DESCRIPTION
- Added `max_count_events` config value, default 5
- Only the last `max_count_events` events are added to a player message
- Changed reload of conversation to only add as many last messages back as their token count doesn't exceed 10% of context size