### PR TITLE
Actor and context data caching

### DIFF
--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -118,14 +118,14 @@ class context:
     def get_time_group(self) -> str:
         return get_time_group(self.__ingame_time)
     
-    def update_context(self, location: str, in_game_time: int, custom_ingame_events: list[str], weather: str, custom_context_values: dict[str, Any]):
+    def update_context(self, location: str | None, in_game_time: int, custom_ingame_events: list[str], weather: str, custom_context_values: dict[str, Any]):
         self.__ingame_events.extend(custom_ingame_events)
         if weather != self.__weather:
             if self.__weather != "":
                 self.__ingame_events.append(weather)
             self.__weather = weather
         self.__custom_context_values = custom_context_values
-        if location != self.__location:
+        if (location) and (location != self.__location):
             self.__location = location
             self.__ingame_events.append(f"The location is now {location}.")
         

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -162,7 +162,7 @@ class conversation:
         else:
             self.__start_generating_npc_sentences()
 
-    def update_context(self, location: str, time: int, custom_ingame_events: list[str], weather: str, custom_context_values: dict[str, Any]):
+    def update_context(self, location: str | None, time: int, custom_ingame_events: list[str], weather: str, custom_context_values: dict[str, Any]):
         """Updates the context with a new set of values
 
         Args:

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -122,7 +122,7 @@ class GameStateManager:
                     actors_in_json.append(actor)
             
             self.__talk.add_or_update_character(actors_in_json)
-            location: str = json[comm_consts.KEY_CONTEXT][comm_consts.KEY_CONTEXT_LOCATION]
+            location: str = json[comm_consts.KEY_CONTEXT].get(comm_consts.KEY_CONTEXT_LOCATION, None)
             time: int = json[comm_consts.KEY_CONTEXT][comm_consts.KEY_CONTEXT_TIME]
             ingame_events: list[str] = json[comm_consts.KEY_CONTEXT][comm_consts.KEY_CONTEXT_INGAMEEVENTS]
             custom_context_values: dict[str, Any] = {}

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -58,8 +58,6 @@ class GameStateManager:
         if(not self.__talk ):
             return self.error_message("No running conversation at this point")
         
-        self.__update_context(input_json) # TODO: check how fast reloading characters each conversation turn is
-        
         if input_json.__contains__(comm_consts.KEY_REQUEST_EXTRA_ACTIONS):
             extra_actions: list[str] = input_json[comm_consts.KEY_REQUEST_EXTRA_ACTIONS]
             if extra_actions.__contains__(comm_consts.ACTION_RELOADCONVERSATION):


### PR DESCRIPTION
- Set location variable as optional to accommodate https://github.com/art-from-the-machine/Mantella-Spell/pull/73
- Context is no longer updated for each voiceline delivered, and is instead only updated when the player speaks