### PR TITLE
Save conversations with generic NPCs

### DIFF
--- a/src/config/definitions/prompt_definitions.py
+++ b/src/config/definitions/prompt_definitions.py
@@ -77,7 +77,7 @@ class PromptDefinitions:
         # TODO: integrate player description "{player_name} is {player_description} {player_equipment} {equipment}" when multi-NPC conversation, but not radiant
         skyrim_multi_npc_prompt = """The following is a conversation in {location} in Skyrim between {names_w_player}.
                                     Here are their backgrounds: {bios}                                    
-                                    And here are their conversation histories: {conversation_summaries}
+                                    {conversation_summaries}
                                     The time is {time} {time_group}. If you directly refer to the time, please state it as, for example, '10 in the evening' rather than '22:00'. 
                                     {weather}
                                     You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'. 

--- a/src/remember/summaries.py
+++ b/src/remember/summaries.py
@@ -8,6 +8,7 @@ from src.llm.messages import user_message
 from src.characters_manager import Characters
 from src.character_manager import Character
 from src.remember.remembering import remembering
+from src import utils
 
 class summaries(remembering):
     """ Stores a conversation as a summary in a text file.
@@ -57,23 +58,27 @@ class summaries(remembering):
 
     def save_conversation_state(self, messages: message_thread, npcs_in_conversation: Characters, world_id: str, is_reload=False):
         summary = ''
-        non_generic_npc: list[Character] = []
         for npc in npcs_in_conversation.get_all_characters():
-            if npc.is_generic_npc:
-                logging.info('A summary will not be saved for this generic NPC.')            
-            elif not npc.is_player_character:
-                non_generic_npc.append(npc)
-        for npc in non_generic_npc:            
-            if len(summary) < 1: # if a summary has not already been generated, make one
-                summary = self.__create_new_conversation_summary(messages, npc.name)
-            if len(summary) > 0 or is_reload: # if a summary has been generated, give the same summary to all NPCs
-                self.__append_new_conversation_summary(summary, npc, world_id)
+            if not npc.is_player_character:
+                if len(summary) < 1: # if a summary has not already been generated, make one
+                    summary = self.__create_new_conversation_summary(messages, npc.name)
+                if len(summary) > 0 or is_reload: # if a summary has been generated, give the same summary to all NPCs
+                    self.__append_new_conversation_summary(summary, npc, world_id)
 
     def __get_latest_conversation_summary_file_path(self, character: Character, world_id: str) -> str:
         """Get latest conversation summary by file name suffix"""
 
-        name: str = character.name
-        character_conversation_folder_path = os.path.join(self.__game.conversation_folder_path, world_id, name)
+        # if multiple NPCs in a conversation have the same name (eg Whiterun Guard) their names are appended with number IDs
+        # these IDs need to be removed when saving the conversation
+        name: str = utils.remove_trailing_number(character.name)
+        
+        name_conversation_folder_path = os.path.join(self.__game.conversation_folder_path, world_id, name)
+        if os.path.exists(name_conversation_folder_path): # if a conversation folder already exists for this NPC, use it
+            character_conversation_folder_path = name_conversation_folder_path
+        else: # else include the NPC's reference ID in the folder name to differentiate generic NPCs
+            name_ref: str = f'{name} - {character.id}'
+            character_conversation_folder_path = os.path.join(self.__game.conversation_folder_path, world_id, name_ref)
+        
         if os.path.exists(character_conversation_folder_path):
             # get all files from the directory
             files = os.listdir(character_conversation_folder_path)

--- a/src/utils.py
+++ b/src/utils.py
@@ -28,6 +28,13 @@ def clean_text(text):
     return text_cleaned
 
 
+def remove_trailing_number(s):
+    try:
+        return re.sub(r'\d+$', '', s)
+    except:
+        return s
+
+
 def resolve_path():
     if getattr(sys, 'frozen', False):
         resolved_path = os.path.dirname(sys.executable)


### PR DESCRIPTION
Made saving conversations with generic NPCs possible. For a given NPC, if a conversation folder already exists, conversations are saved to this folder as usual. However, if this folder does not exist, the saved folder name will be generated in the format "NPC Name - Reference ID". 

This means that moving forward, NPC folder names will be in the "NPC Name - Reference ID" format, while existing NPC folders will remain the same to avoid players having to rename pre-existing NPC folder names. With the new format, including the Reference ID allows unique identification of generic NPCs.