### PR TITLE
Hide `Game` config values when `--integrated` instead of not adding them at all

### DIFF
--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -23,15 +23,15 @@ class MantellaConfigValueDefinitionsNew:
         # hidden_category.add_config_value(ConfigValueBool("show_advanced","","", False, is_hidden=True))
         # result.add_base_group(hidden_category)
 
-        if "--integrated" not in sys.argv: # if integrated, these paths are all relative so do not need to be manually set
-            game_category = ConfigValueGroup("Game", "Game", "Settings for the games Mantella supports.", on_value_change_callback)
-            game_category.add_config_value(GameDefinitions.get_game_config_value())
-            game_category.add_config_value(GameDefinitions.get_skyrim_mod_folder_config_value())
-            game_category.add_config_value(GameDefinitions.get_skyrimvr_mod_folder_config_value())
-            game_category.add_config_value(GameDefinitions.get_fallout4_mod_folder_config_value())
-            game_category.add_config_value(GameDefinitions.get_fallout4vr_mod_folder_config_value())
-            game_category.add_config_value(GameDefinitions.get_fallout4vr_folder_config_value())
-            result.add_base_group(game_category)
+        # if "--integrated" not in sys.argv: # if integrated, these paths are all relative so do not need to be manually set
+        game_category = ConfigValueGroup("Game", "Game", "Settings for the games Mantella supports.", on_value_change_callback,"--integrated" in sys.argv)
+        game_category.add_config_value(GameDefinitions.get_game_config_value())
+        game_category.add_config_value(GameDefinitions.get_skyrim_mod_folder_config_value())
+        game_category.add_config_value(GameDefinitions.get_skyrimvr_mod_folder_config_value())
+        game_category.add_config_value(GameDefinitions.get_fallout4_mod_folder_config_value())
+        game_category.add_config_value(GameDefinitions.get_fallout4vr_mod_folder_config_value())
+        game_category.add_config_value(GameDefinitions.get_fallout4vr_folder_config_value())
+        result.add_base_group(game_category)
         
         llm_category = ConfigValueGroup("LLM", "Large Language Model", "Settings for the LLM providers and the LLMs themselves.", on_value_change_callback)
         llm_category.add_config_value(LLMDefinitions.get_llm_api_config_value())


### PR DESCRIPTION
This change puts the `Game` `ConfigValueGroup` to hidden when Mantella is launched with the `--integrated` command args.
Before it didn't add the config values at all.

This fixes the issues people (and me) were having when switching back and forth between the integrated and not-integrated start of the software.

It is true that there are noe a few config values in the `config.ini` that don'T have any meaning to a normal user but those people are also no longer supposed to edit the `config.ini` directly.