### PR TITLE
Fixed ghost updates from UI

### DIFF
--- a/src/ui/settings_ui_constructor.py
+++ b/src/ui/settings_ui_constructor.py
@@ -63,8 +63,9 @@ class SettingsUIConstructor(ConfigValueVisitor):
     def __on_change(self, config_value: ConfigValue[T], new_value: T) -> gr.Markdown:
         result: ConfigValueConstraintResult = config_value.does_value_cause_error(new_value)
         if result.is_success:
-            config_value.value = new_value
-            logging.info(f'{config_value.name} set to {config_value.value}')           
+            if config_value.value != new_value:
+                config_value.value = new_value
+                logging.info(f'{config_value.name} set to {config_value.value}')
             return self.__construct_error_message_panel('', is_visible=False)
         else:
             return self.__construct_error_message_panel(result.error_message, is_visible=True)


### PR DESCRIPTION
An update to a config value is only made if the new value is different from the old value