### PR TITLE
Added customizable actions

### DIFF
--- a/data/actions/follow.json
+++ b/data/actions/follow.json
@@ -1,0 +1,12 @@
+{
+    "identifier": "mantella_npc_follow",
+    "name": "Follow",
+    "description": "The keyword used by the NPC when they are willing to become a follower.",
+    "key": "Follow",
+    "prompt": "If the player asks you to follow them, and you are thoroughly convinced to do so, begin your response with '{key}:'",
+    "is-interrupting": false,
+    "one-on-one": true,
+    "multi-npc": false,
+    "radiant": false,
+    "info-text": "The NPC is willing to follow the player"
+}

--- a/data/actions/inventory.json
+++ b/data/actions/inventory.json
@@ -1,0 +1,12 @@
+{
+    "identifier": "mantella_npc_inventory",
+    "name": "Inventory",
+    "description": "The keyword used by the NPC when they are willing to show their inventory.",
+    "key": "Inventory",
+    "prompt": "To show the player what you have in your inventory or to give / take an item, begin your response with '{key}:'.",
+    "is-interrupting": true,
+    "one-on-one": true,
+    "multi-npc": false,
+    "radiant": false,
+    "info-text": "The NPC is willing to show their inventory to the player"
+}

--- a/data/actions/offend_forgive.json
+++ b/data/actions/offend_forgive.json
@@ -1,0 +1,26 @@
+[
+    {
+        "identifier": "mantella_npc_offended",
+        "name": "Offended",
+        "description": "The keyword used by the NPC when they are offended.",
+        "key": "Offended",
+        "prompt": "If the player says something hurtful / offensive, begin your response with '{key}:'. Eg 'Have you washed lately?' '{key}: How dare you!'.",
+        "is-interrupting": false,
+        "one-on-one": true,
+        "multi-npc": false,
+        "radiant": false,
+        "info-text": "The player offended the NPC"
+    },
+    {
+        "identifier": "mantella_npc_forgiven",
+        "name": "Forgiven",
+        "description": "The keyword used by the NPC when they have forgiven the player for offending them.",
+        "key": "Forgiven",
+        "prompt": "If the player renounces their words, or to end combat, begin your response with '{key}:'.",
+        "is-interrupting": false,
+        "one-on-one": true,
+        "multi-npc": false,
+        "radiant": false,
+        "info-text": "The player made up with the NPC"
+    }
+]  

--- a/src/config/config_file_writer.py
+++ b/src/config/config_file_writer.py
@@ -63,6 +63,13 @@ class ConfigFileWriter(ConfigValueVisitor):
         lines_to_write.extend(self.__generate_default_and_config_value_lines(config_value))
         self.write_setting_block_to_file(lines_to_write)
 
+    def visit_ConfigValueMultiSelection(self, config_value: ConfigValueSelection):
+        lines_to_write = self.__generate_name_and_description_lines(config_value)
+        lines_to_write.append(f";   Options: {', '.join(config_value.options[:])}{self.NEWLINE}")
+        lines_to_write.append(f";   default = {', '.join(config_value.default_value[:])}{self.NEWLINE}")
+        lines_to_write.append(f"{config_value.identifier} = {', '.join(config_value.value[:])}{self.NEWLINE}")
+        self.write_setting_block_to_file(lines_to_write)
+
     def visit_ConfigValuePath(self, config_value: ConfigValuePath):
         lines_to_write = self.__generate_name_and_description_lines(config_value)
         required_target_text = ""

--- a/src/config/config_json_writer.py
+++ b/src/config/config_json_writer.py
@@ -39,11 +39,11 @@ class ConfigJsonWriter(ConfigValueVisitor):
         result: dict[str, Any] = {}
         result[self.KEY_TYPE] = "group"
         self.__add_id_name_and_description(result, config_value)
-        recursive: ConfigJsonWriter = ConfigJsonWriter()
-        for cf in config_value.value:
-            cf.accept_visitor(recursive)
-        result[self.KEY_VALUE] = recursive.get_Json()
-        self.__content.append(result)
+        # recursive: ConfigJsonWriter = ConfigJsonWriter()
+        # for cf in config_value.value:
+        #     cf.accept_visitor(recursive)
+        # result[self.KEY_VALUE] = recursive.get_Json()
+        # self.__content.append(result)
 
     def visit_ConfigValueInt(self, config_value: ConfigValueInt):
         result: dict[str, Any] = {}

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -2,6 +2,7 @@ import configparser
 import logging
 import os
 import sys
+from src.conversation.action import action
 from src.config.config_values import ConfigValues
 from src.config.mantella_config_value_definitions_new import MantellaConfigValueDefinitionsNew
 from src.config.config_json_writer import ConfigJsonWriter
@@ -12,11 +13,14 @@ import json
 
 class ConfigLoader:
     def __init__(self, mygame_folder_path: str, file_name='config.ini'):
+        self.is_run_integrated = "--integrated" in sys.argv
         self.save_folder = mygame_folder_path
         self.__has_any_value_changed: bool = False        
         self.__is_initial_load: bool = True
         self.__file_name = os.path.join(mygame_folder_path, file_name)
-        self.__definitions: ConfigValues = MantellaConfigValueDefinitionsNew.get_config_values(self.__on_config_value_change)
+        path_to_actions = os.path.join(utils.resolve_path(),"data","actions")
+        self.__actions = self.load_actions_from_json(path_to_actions)
+        self.__definitions: ConfigValues = MantellaConfigValueDefinitionsNew.get_config_values(self.is_run_integrated, self.__actions, self.__on_config_value_change)
         if not os.path.exists(self.__file_name):
             logging.log(24,"Cannot find 'config.ini'. Assuming first time usage of MantellaSoftware and creating it.")
             self.__write_config_state(self.__definitions)
@@ -44,7 +48,7 @@ class ConfigLoader:
             self.__write_config_state(self.__definitions, True)
         
         self.__is_initial_load = False
-        self.__update_config_values_from_current_state()     
+        self.__update_config_values_from_current_state()
     
     @property
     def have_all_config_values_loaded_correctly(self) -> bool:
@@ -125,14 +129,20 @@ class ConfigLoader:
             self.mod_path_base = self.mod_path
             self.mod_path += "\\Sound\\Voice\\Mantella.esp"
 
+            selected_actions = self.__definitions.get_string_list_value("active_actions")
+            self.actions = [a for a in self.__actions if a.name in selected_actions]
+
             self.language = self.__definitions.get_string_value("language")
             self.end_conversation_keyword = self.__definitions.get_string_value("end_conversation_keyword")
             self.goodbye_npc_response = self.__definitions.get_string_value("goodbye_npc_response")
             self.collecting_thoughts_npc_response = self.__definitions.get_string_value("collecting_thoughts_npc_response")
-            self.offended_npc_response = self.__definitions.get_string_value("offended_npc_response")
-            self.forgiven_npc_response = self.__definitions.get_string_value("forgiven_npc_response")
-            self.follow_npc_response = self.__definitions.get_string_value("follow_npc_response")
-            self.inventory_npc_response = self.__definitions.get_string_value("inventory_npc_response")
+            for a in self.__actions:
+                identifier = a.identifier.lstrip("mantella_").lstrip("npc_")
+                a.keyword = self.__definitions.get_string_value(f"{identifier}_npc_response")
+            # self.offended_npc_response = self.__definitions.get_string_value("offended_npc_response")
+            # self.forgiven_npc_response = self.__definitions.get_string_value("forgiven_npc_response")
+            # self.follow_npc_response = self.__definitions.get_string_value("follow_npc_response")
+            # self.inventory_npc_response = self.__definitions.get_string_value("inventory_npc_response")
 
             #TTS
             self.tts_service = self.__definitions.get_string_value("tts_service").strip().lower()
@@ -273,11 +283,42 @@ class ConfigLoader:
             logging.error('Parameter missing/invalid in config.ini file!')
             raise e
     
-    def get_config_value_json(self) -> str:
-        json_writer = ConfigJsonWriter()
-        for definition in self.__definitions.base_groups:
-            definition.accept_visitor(json_writer)
-        return json_writer.get_Json()
+    def load_actions_from_json(self, actions_folder: str) -> list[action]:
+        result = []
+        if not os.path.exists(actions_folder):
+            os.makedirs(actions_folder)
+        override_files: list[str] = os.listdir(actions_folder)
+        for file in override_files:
+            try:
+                filename, extension = os.path.splitext(file)
+                full_path_file = os.path.join(actions_folder,file)
+                if extension == ".json":
+                    with open(full_path_file) as fp:
+                        json_object = json.load(fp)
+                        if isinstance(json_object, dict):#Otherwise it is already a list
+                            json_object = [json_object]
+                        for json_content in json_object:
+                            content: dict[str, str] = json_content
+                            identifier: str = content.get("identifier", "")
+                            name: str = content.get("name", "")
+                            key: str = content.get("key", "")
+                            description: str = content.get("description", "")
+                            prompt: str = content.get("prompt", "")
+                            is_interrupting: bool = bool(content.get("is-interrupting", ""))
+                            one_on_one: bool = bool(content.get("one-on-one", ""))
+                            multi_npc: bool = bool(content.get("multi-npc", ""))
+                            radiant: bool = bool(content.get("radiant", ""))
+                            info_text: str = content.get("info-text", "")
+                            result.append(action(identifier, name, key,description,prompt,is_interrupting, one_on_one,multi_npc,radiant,info_text))
+            except Exception as e:
+                logging.log(logging.WARNING, f"Could not load action definition file '{file}' in '{actions_folder}'. Most likely there is an error in the formating of the file. Error: {e}")
+        return result
+    
+    # def get_config_value_json(self) -> str:
+    #     json_writer = ConfigJsonWriter()
+    #     for definition in self.__definitions.base_groups:
+    #         definition.accept_visitor(json_writer)
+    #     return json_writer.get_Json()
 
         
 

--- a/src/config/config_values.py
+++ b/src/config/config_values.py
@@ -1,4 +1,5 @@
 from typing import Any, TypeVar
+from src.config.types.config_value_multi_selection import ConfigValueMultiSelection
 from src.config.config_value_constraint import ConfigValueConstraintResult
 from src.config.types.config_value import ConfigValue
 from src.config.types.config_value_bool import ConfigValueBool
@@ -20,6 +21,7 @@ class ConfigValues(ConfigValueVisitor):
         self.__bool_values: dict[str, tuple[ConfigValueBool, str]] = {}
         self.__string_values: dict[str, tuple[ConfigValueString, str]] = {}
         self.__selection_values: dict[str, tuple[ConfigValueSelection, str]] = {}
+        self.__multi_selection_values: dict[str, tuple[ConfigValueMultiSelection, str]] = {}
         self.__path_values: dict[str, tuple[ConfigValuePath, str]] = {}
         self.__constraint_violations: dict[str, list[str]] = {}
         self.__last_section_id: str = ""
@@ -64,6 +66,9 @@ class ConfigValues(ConfigValueVisitor):
                 return self.__get_value(self.__selection_values, identifier)
             except:
                 return self.__get_value(self.__path_values, identifier)
+            
+    def get_string_list_value(self, identifier: str) -> list[str]:
+        return self.__get_value(self.__multi_selection_values, identifier)
     
     def clear_constraint_violations(self):
         self.__constraint_violations.clear()
@@ -93,6 +98,10 @@ class ConfigValues(ConfigValueVisitor):
         self.__selection_values[config_value.identifier] = config_value, self.__last_section_id
         self.__all_config_values[config_value.identifier] = config_value
 
+    def visit_ConfigValueMultiSelection(self, config_value: ConfigValueMultiSelection):
+        self.__multi_selection_values[config_value.identifier] = config_value, self.__last_section_id
+        self.__all_config_values[config_value.identifier] = config_value
+
     def visit_ConfigValuePath(self, config_value: ConfigValuePath):
         self.__path_values[config_value.identifier] = config_value, self.__last_section_id
         self.__all_config_values[config_value.identifier] = config_value
@@ -102,7 +111,7 @@ class ConfigValues(ConfigValueVisitor):
             self.__constraint_violations[config_value.identifier] = []
         self.__constraint_violations[config_value.identifier].append(text)
     
-    T = TypeVar('T', int, float, bool, str)
+    T = TypeVar('T', int, float, bool, str, list[str])
     def __get_value(self, dictionary_to_check: dict[str, tuple[Any, str]], identifier: str) -> T:
         if dictionary_to_check.__contains__(identifier):
             config_value, category = dictionary_to_check[identifier]

--- a/src/config/definitions/language_definitions.py
+++ b/src/config/definitions/language_definitions.py
@@ -1,3 +1,4 @@
+from src.conversation.action import action
 from src.config.types.config_value import ConfigValue, ConvigValueTag
 from src.config.types.config_value_selection import ConfigValueSelection
 from src.config.types.config_value_string import ConfigValueString
@@ -21,25 +22,6 @@ class LanguageDefinitions:
         return ConfigValueString("collecting_thoughts_npc_response", "NPC Response: Collecting Thoughts","The response the NPC gives when they need to summarise the conversation because the maximum token count has been reached.","I need to gather my thoughts for a moment", tags=[ConvigValueTag.advanced])
 
     @staticmethod
-    def get_offended_npc_response() -> ConfigValue:
-        description = """The keyword used by the NPC when they are offended.
-                       This should match what is stated in the starting prompt."""
-        return ConfigValueString("offended_npc_response","NPC Response: Offended",description, "Offended", tags=[ConvigValueTag.advanced])
-
-    @staticmethod
-    def get_forgiven_npc_response() -> ConfigValue:
-        description = """The keyword used by the NPC when they have forgiven the player for offending them.
-                        This should match what is stated in the starting prompt."""
-        return ConfigValueString("forgiven_npc_response","NPC Response: Forgiven",description,"Forgiven", tags=[ConvigValueTag.advanced])
-
-    @staticmethod
-    def get_follow_npc_response() -> ConfigValue:
-        description = """The keyword used by the NPC when they are willing to become a follower.
-                        This should match what is stated in the starting prompt."""
-        return ConfigValueString("follow_npc_response","NPC Response: Follow",description,"Follow", tags=[ConvigValueTag.advanced])
-    
-    @staticmethod
-    def get_inventory_npc_response() -> ConfigValue:
-        description = """The keyword used by the NPC when they are willing to show their inventory.
-                        This should match what is stated in the starting prompt."""
-        return ConfigValueString("inventory_npc_response","NPC Response: Inventory",description,"Inventory", tags=[ConvigValueTag.advanced])
+    def get_action_keyword_override(action: action) -> ConfigValue:
+        identifier = action.identifier.lstrip("mantella_").lstrip("npc_")
+        return ConfigValueString(f"{identifier}_npc_response",f"NPC Response override: {action.name}",action.description, action.keyword, tags=[ConvigValueTag.advanced])

--- a/src/config/definitions/other_definitions.py
+++ b/src/config/definitions/other_definitions.py
@@ -1,7 +1,9 @@
+from src.conversation.action import action
 from src.config.types.config_value import ConfigValue, ConvigValueTag
 from src.config.types.config_value_bool import ConfigValueBool
 from src.config.types.config_value_int import ConfigValueInt
 from src.config.types.config_value_string import ConfigValueString
+from src.config.types.config_value_multi_selection import ConfigValueMultiSelection
 
 
 class OtherDefinitions:
@@ -16,7 +18,13 @@ class OtherDefinitions:
         auto_launch_ui_description = """Whether the Mantella UI should launch automatically in your browser."""
         return ConfigValueBool("auto_launch_ui","Auto Launch UI",auto_launch_ui_description,True)
 
-    #Conversation
+    #Conversation        
+    @staticmethod
+    def get_active_actions(actions: list[action]) -> ConfigValue:
+        description = "The actions Mantella will provide."
+        default_value:list[str] = [a.name for a in actions]
+        return ConfigValueMultiSelection("active_actions","Actions to use",description, default_value, default_value)
+
     @staticmethod
     def get_automatic_greeting_config_value() -> ConfigValue:
         automatic_greeting_description = """Should a conversation be started with an automatic greeting from the LLM / NPC.

--- a/src/config/definitions/prompt_definitions.py
+++ b/src/config/definitions/prompt_definitions.py
@@ -23,7 +23,8 @@ class PromptDefinitions:
                                 "time_group", 
                                 "language", 
                                 "conversation_summary",
-                                "conversation_summaries"]
+                                "conversation_summaries",
+                                "actions"]
     
     ALLOWED_PROMPT_VARIABLES_RADIANT = [
                                 "game",
@@ -38,7 +39,8 @@ class PromptDefinitions:
                                 "time_group", 
                                 "language", 
                                 "conversation_summary",
-                                "conversation_summaries"]
+                                "conversation_summaries",
+                                "actions"]
     
     BASE_PROMPT_DESCRIPTION = """The starting prompt sent to the LLM when an NPC is selected.
                                 If you would like to edit this, please ensure that the below dynamic variables are contained in curly brackets {}:
@@ -57,7 +59,8 @@ class PromptDefinitions:
                                 player_name = the name of the player character
                                 player_description = a description of the player character (needs to be added in game or using the config value)
                                 player_equipment = a basic description of the equipment the player character carries
-                                equipment = a basic description of the equipment the NPCs carry"""
+                                equipment = a basic description of the equipment the NPCs carry
+                                actions = instructions for the LLM how to trigger actions"""
     
     BASE_RADIANT_DESCRIPTION = """The starting prompt sent to the LLM when a radiant conversation is started.
                                 If you would like to edit this, please ensure that the below dynamic variables are contained in curly brackets {}:
@@ -71,7 +74,8 @@ class PromptDefinitions:
                                 time_group = the time of day in words (eg "in the morning", "at night")
                                 language = the selected language
                                 conversation_summary = reads the latest conversation summaries for the NPCs stored in data/conversations/NPC_Name/NPC_Name_summary_X.txt
-                                equipment = a basic description of the equipment the NPCs carry"""
+                                equipment = a basic description of the equipment the NPCs carry
+                                actions = instructions for the LLM to trigger actions"""
         
     class PromptChecker(ConfigValueConstraint[str]):
         def __init__(self, allowed_prompt_variables: list[str]) -> None:
@@ -100,9 +104,7 @@ class PromptDefinitions:
                                 The time is {time} {time_group}.
                                 {weather}
                                 You are not an AI language model because there are no AI language models in Skyrim. Do not break character / refer to the fact that you are in a video game.
-                                To show the player what you have in your inventory or to give / take an item, begin your response with 'Inventory:'.
-                                If the player says something hurtful / offensive, begin your response with 'Offended:'. Eg 'Have you washed lately?' 'Offended: How dare you!'. If they renounce their words, or to end combat, begin your response with 'Forgiven:'. 
-                                If the player asks you to follow them, and you are thoroughly convinced to do so, begin your response with 'Follow:'.
+                                {actions}
                                 The conversation takes place in {language}.
                                 {conversation_summary}"""
         return ConfigValueString("skyrim_prompt","Skyrim Prompt",PromptDefinitions.BASE_PROMPT_DESCRIPTION,skyrim_prompt_value,[PromptDefinitions.PromptChecker(PromptDefinitions.ALLOWED_PROMPT_VARIABLES)])
@@ -117,6 +119,7 @@ class PromptDefinitions:
                                     {weather}
                                     You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'.
                                     Please use your own discretion to decide who should speak in a given situation (sometimes responding with all NPCs is suitable).
+                                    {actions}
                                     Remember, you can only respond as {names}. Ensure to use their full name when responding.
                                     The conversation takes place in {language}."""
         return ConfigValueString("skyrim_multi_npc_prompt","Skyrim Multi-NPC Prompt",PromptDefinitions.BASE_PROMPT_DESCRIPTION,skyrim_multi_npc_prompt,[PromptDefinitions.PromptChecker(PromptDefinitions.ALLOWED_PROMPT_VARIABLES)])
@@ -130,6 +133,7 @@ class PromptDefinitions:
                                     {weather}
                                     You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'. 
                                     Please use your own discretion to decide who should speak in a given situation (sometimes responding with all NPCs is suitable). 
+                                    {actions}
                                     Remember, you can only respond as {names}. Ensure to use their full name when responding.
                                     The conversation takes place in {language}."""
         return ConfigValueString("skyrim_radiant_prompt","Skyrim Radiant Conversation Prompt",PromptDefinitions.BASE_RADIANT_DESCRIPTION,skyrim_radiant_prompt,[PromptDefinitions.PromptChecker(PromptDefinitions.ALLOWED_PROMPT_VARIABLES_RADIANT)])
@@ -142,6 +146,7 @@ class PromptDefinitions:
                             Who do you think these belong to?
                             You are having a conversation with {trust} (the player) in {location}.
                             This conversation is a script that will be spoken aloud, so please keep your responses appropriately concise and avoid text-only formatting such as numbered lists.
+                            {actions}
                             The time is {time} {time_group}.
                             The conversation takes place in {language}.
                             {conversation_summary}"""
@@ -154,6 +159,7 @@ class PromptDefinitions:
                             The time is {time} {time_group}.
                             You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'. 
                             Please use your own discretion to decide who should speak in a given situation (sometimes responding with all NPCs is suitable). 
+                            {actions}
                             Remember, you can only respond as {names}. Ensure to use their full name when responding.
                             The conversation takes place in {language}."""
         return ConfigValueString("fallout4_multi_npc_prompt","Fallout 4 Multi-NPC Prompt",PromptDefinitions.BASE_PROMPT_DESCRIPTION,fallout4_multi_npc_prompt,[PromptDefinitions.PromptChecker(PromptDefinitions.ALLOWED_PROMPT_VARIABLES)])
@@ -165,6 +171,7 @@ class PromptDefinitions:
                             The time is {time} {time_group}.
                             You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'. 
                             Please use your own discretion to decide who should speak in a given situation (sometimes responding with all NPCs is suitable). 
+                            {actions}
                             Remember, you can only respond as {names}. Ensure to use their full name when responding.
                             The conversation takes place in {language}."""
         return ConfigValueString("fallout4_radiant_prompt","Fallout 4 Radiant Conversation Prompt",PromptDefinitions.BASE_RADIANT_DESCRIPTION,fallout4_radiant_prompt,[PromptDefinitions.PromptChecker(PromptDefinitions.ALLOWED_PROMPT_VARIABLES_RADIANT)])

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -1,4 +1,5 @@
 from typing import Any, Callable
+from src.conversation.action import action
 from src.config.config_values import ConfigValues
 from src.config.types.config_value_bool import ConfigValueBool
 from src.config.types.config_value import ConfigValue
@@ -16,7 +17,7 @@ import sys
 
 class MantellaConfigValueDefinitionsNew:
     @staticmethod
-    def get_config_values(on_value_change_callback: Callable[..., Any] | None = None) -> ConfigValues:
+    def get_config_values(is_integrated: bool, actions: list[action], on_value_change_callback: Callable[..., Any] | None = None) -> ConfigValues:
         result: ConfigValues = ConfigValues()
 
         # hidden_category= ConfigValueGroup("Hidden", "Hidden", "Don't show these on the UI", on_value_change_callback, is_hidden=True)
@@ -24,7 +25,7 @@ class MantellaConfigValueDefinitionsNew:
         # result.add_base_group(hidden_category)
 
         # if "--integrated" not in sys.argv: # if integrated, these paths are all relative so do not need to be manually set
-        game_category = ConfigValueGroup("Game", "Game", "Settings for the games Mantella supports.", on_value_change_callback,"--integrated" in sys.argv)
+        game_category = ConfigValueGroup("Game", "Game", "Settings for the games Mantella supports.", on_value_change_callback, is_integrated)
         game_category.add_config_value(GameDefinitions.get_game_config_value())
         game_category.add_config_value(GameDefinitions.get_skyrim_mod_folder_config_value())
         game_category.add_config_value(GameDefinitions.get_skyrimvr_mod_folder_config_value())
@@ -98,10 +99,8 @@ class MantellaConfigValueDefinitionsNew:
         language_category.add_config_value(LanguageDefinitions.get_end_conversation_keyword_config_value())
         language_category.add_config_value(LanguageDefinitions.get_goodbye_npc_response())
         language_category.add_config_value(LanguageDefinitions.get_collecting_thoughts_npc_response())
-        language_category.add_config_value(LanguageDefinitions.get_offended_npc_response())
-        language_category.add_config_value(LanguageDefinitions.get_forgiven_npc_response())
-        language_category.add_config_value(LanguageDefinitions.get_follow_npc_response())
-        language_category.add_config_value(LanguageDefinitions.get_inventory_npc_response())
+        for action in actions:
+            language_category.add_config_value(LanguageDefinitions.get_action_keyword_override(action))
         result.add_base_group(language_category)
 
         prompts_category = ConfigValueGroup("Prompts", "Prompts", "Change the basic prompts used by Mantella.", on_value_change_callback)
@@ -122,6 +121,7 @@ class MantellaConfigValueDefinitionsNew:
         other_category.add_config_value(OtherDefinitions.get_port_config_value())
         other_category.add_config_value(OtherDefinitions.get_show_http_debug_messages_config_value())
         other_category.add_config_value(OtherDefinitions.get_remove_mei_folders_config_value())
+        other_category.add_config_value(OtherDefinitions.get_active_actions(actions))
         other_category.add_config_value(OtherDefinitions.get_automatic_greeting_config_value())
         other_category.add_config_value(OtherDefinitions.get_max_count_events_config_value())
         other_category.add_config_value(OtherDefinitions.get_hourly_time_config_value())

--- a/src/config/types/config_value_multi_selection.py
+++ b/src/config/types/config_value_multi_selection.py
@@ -1,0 +1,36 @@
+from src.config.config_value_constraint import ConfigValueConstraint, ConfigValueConstraintResult
+from src.config.types.config_value_visitor import ConfigValueVisitor
+from src.config.types.config_value import ConfigValue, ConvigValueTag
+
+
+class ConfigValueMultiSelection(ConfigValue[list[str]]):
+    def __init__(self, identifier: str, name: str, description: str, default_value: list[str], options: list[str], constraints: list[ConfigValueConstraint[list[str]]] = [], is_hidden: bool = False, tags: list[ConvigValueTag] = []):
+        super().__init__(identifier, name, description, default_value, constraints, is_hidden, tags)
+        self.__options: list[str] = options
+
+    @property
+    def options(self) -> list[str]:
+        return self.__options
+    
+    def does_value_cause_error(self, value_to_check: list[str]) -> ConfigValueConstraintResult:
+        result = super().does_value_cause_error(value_to_check)
+        if not result.is_success:
+            return result
+        if all(e in self.__options for e in value_to_check):
+            return ConfigValueConstraintResult()
+        return ConfigValueConstraintResult(f"All chosen elements for {self.__name} must be from {', '.join(self.__options[:-1]) + ' or ' + self.__options[-1]}")
+    
+    def parse(self, config_value: str) -> ConfigValueConstraintResult:
+        try:
+            value_to_use: list[str] = list(x.strip() for x in config_value.split(","))
+            result = self.does_value_cause_error(value_to_use)
+            if result.is_success:
+                self.value = value_to_use
+                return ConfigValueConstraintResult()
+            else:
+                return result
+        except ValueError:
+            return ConfigValueConstraintResult(f"Error when reading config value '{self.identifier}'.")
+        
+    def accept_visitor(self, visitor: ConfigValueVisitor):
+        visitor.visit_ConfigValueMultiSelection(self)

--- a/src/config/types/config_value_visitor.py
+++ b/src/config/types/config_value_visitor.py
@@ -27,5 +27,9 @@ class ConfigValueVisitor(ABC):
         pass
 
     @abstractmethod
+    def visit_ConfigValueMultiSelection(self, config_value):
+        pass
+
+    @abstractmethod
     def visit_ConfigValuePath(self, config_value):
         pass

--- a/src/conversation/action.py
+++ b/src/conversation/action.py
@@ -1,16 +1,56 @@
 class action:
-    def __init__(self, game_action_identifier: str, keyword: str, info_text: str) -> None:
-        self.__game_action_identifier = game_action_identifier
+    def __init__(self, identifier: str, name: str, keyword: str, description: str, prompt_text: str, 
+                 is_interrupting: bool, one_on_one: bool, multi_npc: bool, radiant: bool, info_text: str) -> None:
+        self.__identifier = identifier
+        self.__name = name
         self.__keyword = keyword
+        self.__description = description
+        self.__prompt_text = prompt_text
+        self.__is_interrupting = is_interrupting
+        self.__one_on_one = one_on_one
+        self.__multi_npc = multi_npc
+        self.__radiant = radiant
         self.__info_text = info_text
 
     @property
-    def game_action_identifier(self) -> str:
-        return self.__game_action_identifier
+    def identifier(self) -> str:
+        return self.__identifier
+    
+    @property
+    def name(self) -> str:
+        return self.__name
 
     @property
     def keyword(self) -> str:
         return self.__keyword
+    
+    @property
+    def description(self) -> str:
+        return self.__description
+    
+    @keyword.setter
+    def keyword(self, value: str):
+        self.__keyword = value
+
+    @property
+    def prompt_text(self) -> str:
+        return self.__prompt_text
+    
+    @property
+    def is_interrupting(self) -> bool:
+        return self.__is_interrupting
+    
+    @property
+    def use_in_on_on_one(self) -> bool:
+        return self.__one_on_one
+    
+    @property
+    def use_in_multi_npc(self) -> bool:
+        return self.__multi_npc
+    
+    @property
+    def use_in_radiant(self) -> bool:
+        return self.__radiant
     
     @property
     def info_text(self) -> str:

--- a/src/conversation/conversation_type.py
+++ b/src/conversation/conversation_type.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from src.config.config_loader import ConfigLoader
+from src.conversation.action import action
 from src.character_manager import Character
 from src.llm.message_thread import message_thread
 from src.conversation.context import context
@@ -7,9 +9,9 @@ from src.llm.messages import user_message
 class conversation_type(ABC):
     """Base class for different forms of conversations.
     """
-    def __init__(self, prompt: str) -> None:
+    def __init__(self, config: ConfigLoader) -> None:
         super().__init__()
-        self._prompt = prompt
+        self._config = config
     
     @abstractmethod
     def generate_prompt(self, context_for_conversation: context) -> str:
@@ -60,11 +62,12 @@ class conversation_type(ABC):
 
 class pc_to_npc(conversation_type):
     """PC talks to a single NPC. The classic conversation"""
-    def __init__(self, prompt: str) -> None:
-        super().__init__(prompt)
+    def __init__(self, config: ConfigLoader) -> None:
+        super().__init__(config)
 
     def generate_prompt(self, context_for_conversation: context) -> str:
-        return context_for_conversation.generate_system_message(self._prompt)
+        actions = [a for a in self._config.actions if a.use_in_on_on_one]
+        return context_for_conversation.generate_system_message(self._config.prompt, actions)
     
     def adjust_existing_message_thread(self, message_thread_to_adjust: message_thread, context_for_conversation: context):
         message_thread_to_adjust.modify_messages(self.generate_prompt(context_for_conversation), multi_npc_conversation=False, remove_system_flagged_messages=True)
@@ -84,24 +87,26 @@ class pc_to_npc(conversation_type):
 
 class multi_npc(conversation_type):
     """Group conversation between the PC and multiple NPCs"""
-    def __init__(self, prompt: str) -> None:
-        super().__init__(prompt)
+    def __init__(self, config: ConfigLoader) -> None:
+        super().__init__(config)
 
     def generate_prompt(self, context_for_conversation: context) -> str:
-        return context_for_conversation.generate_system_message(self._prompt)
+        actions = [a for a in self._config.actions if a.use_in_multi_npc]
+        return context_for_conversation.generate_system_message(self._config.multi_npc_prompt, actions)
     
     def adjust_existing_message_thread(self, message_thread_to_adjust: message_thread, context_for_conversation: context):
         message_thread_to_adjust.modify_messages(self.generate_prompt(context_for_conversation), True, True)
 
 class radiant(conversation_type):
     """ Conversation between two NPCs without the player"""
-    def __init__(self, context_for_conversation: context) -> None:
-        super().__init__(context_for_conversation.config.radiant_prompt)
-        self.__user_start_prompt = context_for_conversation.config.radiant_start_prompt
-        self.__user_end_prompt = context_for_conversation.config.radiant_end_prompt
+    def __init__(self, config: ConfigLoader) -> None:
+        super().__init__(config)
+        self.__user_start_prompt = config.radiant_start_prompt
+        self.__user_end_prompt = config.radiant_end_prompt
 
     def generate_prompt(self, context_for_conversation: context) -> str:
-        return context_for_conversation.generate_system_message(self._prompt)
+        actions = [a for a in self._config.actions if a.use_in_radiant]
+        return context_for_conversation.generate_system_message(self._config.radiant_prompt, actions)
     
     def adjust_existing_message_thread(self, message_thread_to_adjust: message_thread, context_for_conversation: context):
         message_thread_to_adjust.modify_messages(self.generate_prompt(context_for_conversation), True, True)

--- a/src/ui/settings_ui_constructor.py
+++ b/src/ui/settings_ui_constructor.py
@@ -8,6 +8,7 @@ from src.config.types.config_value_path import ConfigValuePath
 from src.config.types.config_value_bool import ConfigValueBool
 from src.config.types.config_value_float import ConfigValueFloat
 from src.config.types.config_value_selection import ConfigValueSelection
+from src.config.types.config_value_multi_selection import ConfigValueMultiSelection
 from src.config.types.config_value_string import ConfigValueString
 from src.config.config_value_constraint import ConfigValueConstraintResult
 from src.config.types.config_value import ConfigValue, ConvigValueTag
@@ -196,6 +197,21 @@ class SettingsUIConstructor(ConfigValueVisitor):
         if config_value.identifier == "model":
             additional_buttons = [("Update list", update_model_list)]
         self.__create_config_value_ui_element(config_value, create_input_component,additional_buttons=additional_buttons)
+
+    def visit_ConfigValueMultiSelection(self, config_value: ConfigValueMultiSelection):
+        def create_input_component(raw_config_value: ConfigValue) -> gr.Dropdown:
+            config_value = typing.cast(ConfigValueMultiSelection, raw_config_value)
+            values: list[str | int | float] = []
+            for s in config_value.value:
+                values.append(s)
+            return gr.Dropdown(value=values,                        
+                choices=config_value.options, # type: ignore
+                multiselect=True,
+                allow_custom_value=False, 
+                show_label=False,
+                container=False)
+            
+        self.__create_config_value_ui_element(config_value, create_input_component)
 
     def visit_ConfigValuePath(self, config_value: ConfigValuePath):
         def on_pick_click() -> str | None:


### PR DESCRIPTION
- moves the definition of actions to JSON files located in `.\data\actions`
- adding a new action is now as simple as adding a new JSON file to the folder which can also be done by mods
- actions are now dynamically inserted into the prompts using the new `{actions}` variable and respect the language override
- adds multi-select config values that support `list[str]`. Both for loading from and saving to the `config.ini` as well as displaying them in the UI
- add `active_actions` config value that allows a user to turn actions on and off
- language override config values for the keywords of actions are generated automatically

@art-from-the-machine 
I was not able to trigger the inventory action in any way although I see a clear `mantella_npc_inventory` action going out as part of a sentence but on the Skyrim side nothing happens. The other actions all work correctly.
Did I miss something else that needs to be done for the inventory action to work in Skyrim? I activated it in the MCM.