### PR TITLE
Add missing languages to configuration definitions.

### DIFF
--- a/src/config/definitions/language_definitions.py
+++ b/src/config/definitions/language_definitions.py
@@ -6,7 +6,7 @@ from src.config.types.config_value_string import ConfigValueString
 class LanguageDefinitions:    
     @staticmethod
     def get_language_config_value() -> ConfigValue:
-        return ConfigValueSelection("language","Language","The language used by ChatGPT, xVASynth, and Whisper.","en",["en", "ar", "da", "de", "el", "es", "fi", "fr", "hu", "it", "ko", "nl", "pl", "pt", "ro", "ru", "sv", "sw", "uk", "ha", "tr", "vi", "yo"])
+        return ConfigValueSelection("language","Language","The language used by ChatGPT, xVASynth, and Whisper.","en",["en", "ar", "cs", "da", "de", "el", "es", "fi", "fr", "hi", "hu", "it", "ja", "ko", "nl", "pl", "pt", "ro", "ru", "sv", "sw", "uk", "ha", "tr", "vi", "yo"])
     
     @staticmethod
     def get_end_conversation_keyword_config_value() -> ConfigValue:

--- a/src/config/definitions/stt_definitions.py
+++ b/src/config/definitions/stt_definitions.py
@@ -41,7 +41,7 @@ class STTDefinitions:
     @staticmethod
     def get_stt_language_config_value() -> ConfigValue:
         description = """The player's spoken language."""
-        return ConfigValueSelection("stt_language","STT Language",description,"default",["default","en", "ar", "da", "de", "el", "es", "fi", "fr", "hu", "it", "ko", "nl", "pl", "pt", "ro", "ru", "sv", "sw", "uk", "ha", "tr", "vi", "yo"], tags=[ConvigValueTag.advanced])
+        return ConfigValueSelection("stt_language","STT Language",description,"default",["default","en", "ar", "cs", "da", "de", "el", "es", "fi", "fr", "hi", "hu", "it", "ja", "ko", "nl", "pl", "pt", "ro", "ru", "sv", "sw", "uk", "ha", "tr", "vi", "yo"], tags=[ConvigValueTag.advanced])
 
     @staticmethod
     def get_stt_translate_config_value() -> ConfigValue:


### PR DESCRIPTION
XTTS supports 17 languages, and whisper supports all of those languages. This adds extra languages to the configuration. See: [discord dev post](https://discord.com/channels/1114128157554004011/1145479699645087744/1287466151114444860).