### PR TITLE
Added Mantella request to force settings to initialize

### DIFF
--- a/src/http/communication_constants.py
+++ b/src/http/communication_constants.py
@@ -4,11 +4,13 @@ class communication_constants:
     KEY_REQUESTTYPE: str = PREFIX + "request_type"
     KEY_REPLYTYPE: str = PREFIX + "reply_type"
 
+    KEY_REQUESTTYPE_INIT: str = PREFIX + "initialize"
     KEY_REQUESTTYPE_STARTCONVERSATION: str = PREFIX + "start_conversation"
     KEY_REQUESTTYPE_CONTINUECONVERSATION: str = PREFIX + "continue_conversation"
     KEY_REQUESTTYPE_PLAYERINPUT: str = PREFIX + "player_input"
     KEY_REQUESTTYPE_ENDCONVERSATION: str = PREFIX + "end_conversation"
 
+    KEY_REPLYTTYPE_INITCOMPLETED: str = PREFIX + "init_completed"
     KEY_REPLYTTYPE_STARTCONVERSATIONCOMPLETED: str = PREFIX + "start_conversation_completed"
 
     KEY_REQUEST_EXTRA_ACTIONS: str = PREFIX + "extra_actions"


### PR DESCRIPTION
Added an "initialization" request to force `_setup_route()` to trigger. This allows the server to pre-prepare for a conversation rather than this process only being triggered when a conversation is started (and adding unnecessary run time).

See here for the Mantella Spell implementation of this request type: https://github.com/art-from-the-machine/Mantella-Spell/pull/104