### PR TITLE
Added in game events refresh timer

### DIFF
--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -252,6 +252,7 @@ LLM parameter list must follow the Python dictionary format: https://www.w3schoo
             #Conversation
             self.automatic_greeting = self.__definitions.get_bool_value("automatic_greeting")
             self.max_count_events = self.__definitions.get_int_value("max_count_events")
+            self.events_refresh_time = self.__definitions.get_int_value("events_refresh_time")
             self.hourly_time = self.__definitions.get_bool_value("hourly_time")
             self.player_character_description: str = self.__definitions.get_string_value("player_character_description")
             self.voice_player_input: bool = self.__definitions.get_bool_value("voice_player_input")

--- a/src/config/definitions/other_definitions.py
+++ b/src/config/definitions/other_definitions.py
@@ -54,10 +54,17 @@ class OtherDefinitions:
         return ConfigValueInt("max_count_events","Max Count Events",max_count_events_description,5,0,999999,tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
     
     @staticmethod
+    def get_events_refresh_time_config_value() -> ConfigValue:
+        max_count_events_description = """Determines how much time (in seconds) can pass between the last NPC's response and the player's input before in-game events need to be refreshed.
+                                        Note that updating in-game events increases response times. If the player responds before this set number in seconds, response times will be reduced.
+                                        Increase this value to allow more time for the player to respond before events need to be refreshed. Decrease this value to make in-game events more up to date."""
+        return ConfigValueInt("events_refresh_time","Time to Wait before Updating Events",max_count_events_description,10,0,999999,tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+    
+    @staticmethod
     def get_hourly_time_config_value() -> ConfigValue:
         description = """If enabled, NPCs will be made aware of the time every in-game hour. Otherwise, time updates will be less granular (eg 'The conversation now takes place in the morning' / 'at night' etc).
                         To remove mentions of the hour entirely, prompts also need to be edited from 'The time is {time} {time_group}.' to 'The conversation takes place {time_group}.'"""
-        return ConfigValueBool("hourly_time","Report In-Game Time Hourly",description,False,tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+        return ConfigValueBool("hourly_time","Report In-Game Time Hourly",description,False,tags=[ConfigValueTag.advanced])
     
     #Player Character
     @staticmethod

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -133,6 +133,7 @@ class MantellaConfigValueDefinitionsNew:
         other_category.add_config_value(OtherDefinitions.get_automatic_greeting_config_value())
         other_category.add_config_value(OtherDefinitions.get_active_actions(actions))
         other_category.add_config_value(OtherDefinitions.get_max_count_events_config_value())
+        other_category.add_config_value(OtherDefinitions.get_events_refresh_time_config_value())
         other_category.add_config_value(OtherDefinitions.get_hourly_time_config_value())
         other_category.add_config_value(OtherDefinitions.get_player_character_description())
         other_category.add_config_value(OtherDefinitions.get_voice_player_input())

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -107,11 +107,13 @@ class GameStateManager:
         if(not self.__talk ):
             return self.error_message("No running conversation.")
         
-        player_text: str = input_json[comm_consts.KEY_REQUESTTYPE_PLAYERINPUT]
+        player_text: str = input_json.get(comm_consts.KEY_REQUESTTYPE_PLAYERINPUT, '')
         self.__update_context(input_json)
-        self.__talk.process_player_input(player_text)
+        updated_player_text, update_events = self.__talk.process_player_input(player_text)
+        if update_events:
+            return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REQUESTTYPE_TTS, comm_consts.KEY_TRANSCRIBE: updated_player_text}
 
-        cleaned_player_text = utils.clean_text(player_text)
+        cleaned_player_text = utils.clean_text(updated_player_text)
         npcs_in_conversation = self.__talk.context.npcs_in_conversation
         if not npcs_in_conversation.contains_multiple_npcs(): # actions are only enabled in 1-1 conversations
             for action in self.__config.actions:


### PR DESCRIPTION
Added timer to decide whether or not in-game events need to be updated once the player has spoken.

When an NPC is finished speaking, the latest in-game events are passed to the Mantella window. However, the player doesn't always respond immediately, so if `events_refresh_time` has passed, a request to update events will be passed to the game before passing the player's input and events to the LLM.