### PR TITLE
Path fix for VR LipGen folders

### DIFF
--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -91,7 +91,7 @@ class ConfigLoader:
                 # Working backwards from MantellaSoftware (where the .exe runs) -> Plugins -> F4SE/SKSE -> Data (mod folder)
                 self.mod_path = str(exe_folder.parent.parent.parent)
 
-                self.lipgen_path = self.game_path
+                self.lipgen_path = self.game_path+"\\Tools\\LipGen\\"
                 self.facefx_path = self.mod_path+"\\Sound\\Voice\\Processing\\"
                 self.piper_path = str(Path(utils.resolve_path())) + "\\piper"
 
@@ -102,13 +102,19 @@ class ConfigLoader:
                         # Fallout 4 VR uses the same creation kit as Fallout 4, so the lip gen folder needs to be set to the Fallout 4 folder
                         # Note that this path assumes that both Fallout 4 versions are installed in the same directory
                         # Working backwards from MantellaSoftware (where the .exe runs) -> Plugins -> F4SE -> Data -> Fallout 4 VR -> common (Steam folder for all games)
-                        self.lipgen_path = str(exe_folder.parent.parent.parent.parent.parent)+"\\Fallout 4"
+                        if not os.path.exists(self.lipgen_path):
+                            self.lipgen_path = str(exe_folder.parent.parent.parent.parent.parent)+"\\Fallout 4"+"\\Tools\\LipGen\\"
+                            if not os.path.exists(self.lipgen_path):
+                                self.lipgen_path = ''
                     elif 'skyrim' in game_parent_folder_name:
                         self.game = 'SkyrimVR'
                         # Skyrim VR uses the same creation kit as Skyrim Special Edition, so the lip gen folder needs to be set to the Skyrim Special Edition folder
                         # Note that this path assumes that both Skyrim versions are installed in the same directory
                         # Working backwards from MantellaSoftware (where the .exe runs) -> Plugins -> SKSE -> Data -> Skyrim VR -> common (Steam folder for all games)
-                        self.lipgen_path = str(exe_folder.parent.parent.parent.parent.parent)+"\\Skyrim Special Edition"
+                        if not os.path.exists(self.lipgen_path):
+                            self.lipgen_path = str(exe_folder.parent.parent.parent.parent.parent)+"\\Skyrim Special Edition"+"\\Tools\\LipGen\\"
+                            if not os.path.exists(self.lipgen_path):
+                                self.lipgen_path = ''
                 else:
                     if 'fallout' in game_parent_folder_name:
                         self.game = 'Fallout4'

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -84,15 +84,31 @@ class ConfigLoader:
         try:
             # if the exe is being run by another process, replace config.ini paths with relative paths
             if "--integrated" in sys.argv:
-                self.game_path = str(Path(utils.resolve_path()).parent.parent.parent.parent)
-                self.mod_path = str(Path(utils.resolve_path()).parent.parent.parent)
+                # Plugins/MantellaSoftware folder
+                exe_folder = Path(utils.resolve_path())
+                # Working backwards from MantellaSoftware (where the .exe runs) -> Plugins -> F4SE/SKSE -> Data (mod folder) -> Game
+                self.game_path = str(exe_folder.parent.parent.parent.parent)
+                # Working backwards from MantellaSoftware (where the .exe runs) -> Plugins -> F4SE/SKSE -> Data (mod folder)
+                self.mod_path = str(exe_folder.parent.parent.parent)
+
+                self.lipgen_path = self.game_path
+                self.facefx_path = self.mod_path+"\\Sound\\Voice\\Processing\\"
+                self.piper_path = str(Path(utils.resolve_path())) + "\\piper"
 
                 game_parent_folder_name = os.path.basename(self.game_path).lower()
                 if 'vr' in game_parent_folder_name:
                     if 'fallout' in game_parent_folder_name:
                         self.game = 'Fallout4VR'
+                        # Fallout 4 VR uses the same creation kit as Fallout 4, so the lip gen folder needs to be set to the Fallout 4 folder
+                        # Note that this path assumes that both Fallout 4 versions are installed in the same directory
+                        # Working backwards from MantellaSoftware (where the .exe runs) -> Plugins -> F4SE -> Data -> Fallout 4 VR -> common (Steam folder for all games)
+                        self.lipgen_path = str(exe_folder.parent.parent.parent.parent.parent)+"\\Fallout 4"
                     elif 'skyrim' in game_parent_folder_name:
                         self.game = 'SkyrimVR'
+                        # Skyrim VR uses the same creation kit as Skyrim Special Edition, so the lip gen folder needs to be set to the Skyrim Special Edition folder
+                        # Note that this path assumes that both Skyrim versions are installed in the same directory
+                        # Working backwards from MantellaSoftware (where the .exe runs) -> Plugins -> SKSE -> Data -> Skyrim VR -> common (Steam folder for all games)
+                        self.lipgen_path = str(exe_folder.parent.parent.parent.parent.parent)+"\\Skyrim Special Edition"
                 else:
                     if 'fallout' in game_parent_folder_name:
                         self.game = 'Fallout4'
@@ -100,11 +116,6 @@ class ConfigLoader:
                         self.game = 'Skyrim'
                     else: # default to Skyrim
                         self.game = 'Skyrim'
-
-                self.lipgen_path = self.game_path
-                self.facefx_path = self.mod_path+"\\Sound\\Voice\\Processing\\"
-                #self.xvasynth_path = str(Path(utils.resolve_path())) + "\\xVASynth"
-                self.piper_path = str(Path(utils.resolve_path())) + "\\piper"
 
             else:
                 #Adjusting game and mod paths according to the game being ran

--- a/src/tts/ttsable.py
+++ b/src/tts/ttsable.py
@@ -167,7 +167,7 @@ class ttsable(ABC):
 
         def generate_facefx_lip_file(facefx_path: str, wav_file: str, lip_file: str, voiceline: str, game: str) -> None:
             # Bethesda's LipGen:
-            LipGen_path = Path(self._lipgen_path) / "Tools/LipGen/LipGenerator/LipGenerator.exe"
+            LipGen_path = Path(self._lipgen_path) / "LipGenerator/LipGenerator.exe"
 
             if os.path.exists(LipGen_path):
                 #TODO: Use supported languages here: FR, DE, ES, IT, KO, JP
@@ -215,7 +215,7 @@ class ttsable(ABC):
         def generate_fuz_file(facefx_path: str, wav_file: str, lip_file: str) -> None:
             #Fuz files needed for Fallout only
             #LipFuzer is Bethesda's official fuz creator
-            LipFuz_path = Path(self._lipgen_path) / "Tools/LipGen/LipFuzer/LipFuzer.exe"
+            LipFuz_path = Path(self._lipgen_path) / "LipFuzer/LipFuzer.exe"
 
             if os.path.exists(LipFuz_path):
                 commands = [


### PR DESCRIPTION
If the Creation Kit is installed, the Creation Kit files will be installed in the flat versions of Fallout and Skyrim. To work around this, Mantella will check if it can find the flat version of the game in the same folder as the VR version.