### PR TITLE
Add handling of alternating voice line files

### DIFF
--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -81,6 +81,8 @@ class GameStateManager:
             if extra_actions.__contains__(comm_consts.ACTION_RELOADCONVERSATION):
                 self.__talk.reload_conversation()
 
+        topicInfoID: int = int(input_json.get(comm_consts.KEY_CONTINUECONVERSATION_TOPICINFOFILE,1))
+
         self.__update_context(input_json)
 
         while True:
@@ -95,8 +97,8 @@ class GameStateManager:
 
         if sentence_to_play:
             if not sentence_to_play.error_message:
-                self.__game.prepare_sentence_for_game(sentence_to_play, self.__talk.context, self.__config)            
-                reply[comm_consts.KEY_REPLYTYPE_NPCTALK] = self.sentence_to_json(sentence_to_play)
+                self.__game.prepare_sentence_for_game(sentence_to_play, self.__talk.context, self.__config, topicInfoID)            
+                reply[comm_consts.KEY_REPLYTYPE_NPCTALK] = self.sentence_to_json(sentence_to_play, topicInfoID)
             else:
                 self.__talk.end()
                 return self.error_message(sentence_to_play.error_message)
@@ -150,14 +152,15 @@ class GameStateManager:
         }
     
     @utils.time_it
-    def sentence_to_json(self, sentence_to_prepare: sentence) -> dict[str, Any]:
+    def sentence_to_json(self, sentence_to_prepare: sentence, topicID: int) -> dict[str, Any]:
         return {
             comm_consts.KEY_ACTOR_SPEAKER: sentence_to_prepare.speaker.name,
             comm_consts.KEY_ACTOR_LINETOSPEAK: self.__abbreviate_text(sentence_to_prepare.text.strip()),
             comm_consts.KEY_ACTOR_ISNARRATION: sentence_to_prepare.is_narration,
             comm_consts.KEY_ACTOR_VOICEFILE: sentence_to_prepare.voice_file,
             comm_consts.KEY_ACTOR_DURATION: sentence_to_prepare.voice_line_duration,
-            comm_consts.KEY_ACTOR_ACTIONS: sentence_to_prepare.actions
+            comm_consts.KEY_ACTOR_ACTIONS: sentence_to_prepare.actions,
+            comm_consts.KEY_CONTINUECONVERSATION_TOPICINFOFILE: topicID
         }
     
     def __abbreviate_text(self, text_to_abbreviate: str) -> str:

--- a/src/games/fallout4.py
+++ b/src/games/fallout4.py
@@ -187,7 +187,7 @@ class fallout4(gameable):
         return character_info
     
     @utils.time_it
-    def prepare_sentence_for_game(self, queue_output: sentence, context_of_conversation: context, config: ConfigLoader):
+    def prepare_sentence_for_game(self, queue_output: sentence, context_of_conversation: context, config: ConfigLoader, topicID: int):
         audio_file = queue_output.voice_file
         fuz_file = audio_file.replace(".wav",".fuz")
         speaker = queue_output.speaker

--- a/src/games/gameable.py
+++ b/src/games/gameable.py
@@ -98,7 +98,7 @@ class gameable(ABC):
         pass    
 
     @abstractmethod
-    def prepare_sentence_for_game(self, queue_output: sentence, context_of_conversation: context, config: ConfigLoader):
+    def prepare_sentence_for_game(self, queue_output: sentence, context_of_conversation: context, config: ConfigLoader, topicID: int):
         """Does what ever is needed to play a sentence ingame
 
         Args:

--- a/src/games/skyrim.py
+++ b/src/games/skyrim.py
@@ -12,11 +12,13 @@ from src.games.external_character_info import external_character_info
 from src.games.gameable import gameable
 import src.utils as utils
 
-
 class skyrim(gameable):
     WAV_FILE = f'MantellaDi_MantellaDialogu_00001D8B_1.wav'
     FUZ_FILE = f'MantellaDi_MantellaDialogu_00001D8B_1.fuz'
     LIP_FILE = f'MantellaDi_MantellaDialogu_00001D8B_1.lip'
+    WAV_FILE2 = f'MantellaDi_MantellaDialogu_001A9C49_1.wav'
+    FUZ_FILE2 = f'MantellaDi_MantellaDialogu_001A9C49_1.fuz'
+    LIP_FILE2 = f'MantellaDi_MantellaDialogu_001A9C49_1.lip'
     #Weather constants
     KEY_CONTEXT_WEATHER_ID = "mantella_weather_id"
     KEY_CONTEXT_WEATHER_CLASSIFICATION = "mantella_weather_classification"
@@ -156,7 +158,7 @@ class skyrim(gameable):
         return character_info
     
     @utils.time_it
-    def prepare_sentence_for_game(self, queue_output: sentence, context_of_conversation: context, config: ConfigLoader):
+    def prepare_sentence_for_game(self, queue_output: sentence, context_of_conversation: context, config: ConfigLoader, topicID: int):
         """Save voicelines and subtitles to the correct game folders"""
 
         audio_file = queue_output.voice_file
@@ -166,10 +168,15 @@ class skyrim(gameable):
         # subtitle = queue_output.sentence
         speaker: Character = queue_output.speaker
         voice_folder_path = f"{mod_folder}/MantellaVoice00"
-        os.makedirs(voice_folder_path, exist_ok=True)
-        shutil.copyfile(audio_file, f"{voice_folder_path}/{self.WAV_FILE}")
+        os.makedirs(voice_folder_path, exist_ok=True)        
+        wav_file_name = self.WAV_FILE
+        lip_file_name = self.LIP_FILE
+        if topicID == 2:
+            wav_file_name = self.WAV_FILE2
+            lip_file_name = self.LIP_FILE2
+        shutil.copyfile(audio_file, f"{voice_folder_path}/{wav_file_name}")
         try:
-            shutil.copyfile(audio_file.replace(".wav", ".lip"), f"{voice_folder_path}/{self.LIP_FILE}")
+            shutil.copyfile(audio_file.replace(".wav", ".lip"), f"{voice_folder_path}/{lip_file_name}")
         except Exception as e:
             # only warn on failure
             pass

--- a/src/http/communication_constants.py
+++ b/src/http/communication_constants.py
@@ -22,6 +22,7 @@ class communication_constants:
 
     KEY_STARTCONVERSATION_WORLDID: str = PREFIX + "worldid"
     KEY_STARTCONVERSATION_USENARRATOR: str = PREFIX + "use_narrator"
+    KEY_CONTINUECONVERSATION_TOPICINFOFILE: str = PREFIX + "topicinfofile"
     KEY_INPUTTYPE: str = PREFIX + "input_type"
     KEY_INPUTTYPE_MIC: str = PREFIX + "mic_input"
     KEY_INPUTTYPE_TEXT: str = PREFIX + "text_input"


### PR DESCRIPTION
- Uses two different voice line files
- This fixes the issue when a voice line file is already replaced with the next one before/while it is being played ingame
- requires [this Mantella-Spell PR](https://github.com/art-from-the-machine/Mantella-Spell/pull/110)
- only implemented for Skyrim right now