### PR TITLE
Remove temperature from default LLM settings

### DIFF
--- a/src/config/definitions/llm_definitions.py
+++ b/src/config/definitions/llm_definitions.py
@@ -76,7 +76,6 @@ class LLMDefinitions:
     def get_llm_params_config_value() -> ConfigValue:
         value = """{
                         "max_tokens": 250,
-                        "temperature": 1.0,
                         "stop": ["#"]
                     }"""
         description = """Parameters passed as part of the request to the LLM.

--- a/src/config/definitions/vision_definitions.py
+++ b/src/config/definitions/vision_definitions.py
@@ -76,7 +76,6 @@ class VisionDefinitions:
     def get_vision_llm_params_config_value() -> ConfigValue:
         value = """{
                         "max_tokens": 100,
-                        "temperature": 1.0,
                         "stop": ["#"]
                     }"""
         description = """Parameters passed as part of the request to the vision model.


### PR DESCRIPTION
The recommended temperature setting can change from one LLM to another. Because of this, the default temperature setting of 1.0 has been removed on the Mantella side, allowing the LLM service to choose the appropriate default temperature.