### PR TITLE
Add local moonshine model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ mss==9.0.1
 opencv-python==4.10.0.84
 sounddevice==0.5.1
 silero_vad==5.1.2
-git+https://github.com/usefulsensors/moonshine.git@6a0846b556ca1c1f2f373996fe53b0b79e23cc17#subdirectory=moonshine-onnx
+git+https://github.com/usefulsensors/moonshine.git@2f6282347950c8d711bd7319287babb87ec5a92d#subdirectory=moonshine-onnx

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -95,6 +95,7 @@ class ConfigLoader:
                 self.lipgen_path = self.game_path+"\\Tools\\LipGen\\"
                 self.facefx_path = self.mod_path+"\\Sound\\Voice\\Processing\\"
                 self.piper_path = str(Path(utils.resolve_path())) + "\\piper"
+                self.moonshine_folder = str(Path(utils.resolve_path()))
 
                 game_parent_folder_name = os.path.basename(self.game_path).lower()
                 if 'vr' in game_parent_folder_name:
@@ -214,6 +215,11 @@ class ConfigLoader:
             #STT
             self.stt_service = self.__definitions.get_string_value("stt_service").lower()
             self.moonshine_model = self.__definitions.get_string_value("moonshine_model_size")
+            if not hasattr(self, 'moonshine_folder'):
+                try:
+                    self.moonshine_folder = str(Path(self.__definitions.get_string_value("moonshine_folder")).parent) # go up one folder since moonshine/ is in the model name
+                except:
+                    self.moonshine_folder = ''
             self.whisper_model = self.__definitions.get_string_value("whisper_model_size")
             self.whisper_process_device = self.__definitions.get_string_value("process_device")
             self.stt_language = self.__definitions.get_string_value("stt_language")

--- a/src/config/definitions/stt_definitions.py
+++ b/src/config/definitions/stt_definitions.py
@@ -63,9 +63,15 @@ Depending on your NVIDIA CUDA version, setting the Whisper process device to `cu
     
     @staticmethod
     def get_moonshine_model_size_config_value() -> ConfigValue:
-        description = """The size of the Moonshine model to use. The larger the model, the more accurate the transcription (at the cost of speed)."""
-        options = ["moonshine/tiny", "moonshine/base"]
-        return ConfigValueSelection("moonshine_model_size", "Moonshine Model", description, "moonshine/tiny", options, allows_free_edit=True, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+        description = """The size of the Moonshine model to use (sorted from smallest to largest). The larger the model, the more accurate the transcription (at the cost of speed)."""
+        options = ["moonshine/tiny/quantized_4bit", 
+                   "moonshine/tiny/quantized", 
+                   "moonshine/tiny/float", 
+                   "moonshine/base/quantized_4bit",
+                   "moonshine/base/quantized",
+                   "moonshine/base/float"
+                   ]
+        return ConfigValueSelection("moonshine_model_size", "Moonshine Model", description, "moonshine/tiny/quantized", options, allows_free_edit=True, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
     
     @staticmethod
     def get_whisper_model_size_config_value() -> ConfigValue:
@@ -125,3 +131,8 @@ Depending on your NVIDIA CUDA version, setting the Whisper process device to `cu
     def get_process_device_config_value() -> ConfigValue:
         description = "Whether to run Whisper on your CPU or NVIDIA GPU (with CUDA installed) (only impacts faster_whisper option, no impact on whispercpp, which is controlled by your server)."
         return ConfigValueSelection("process_device", "Whisper Process Device", description,"cpu",["cpu","cuda"], constraints=[STTDefinitions.WhisperProcessDeviceChecker()], tags=[ConfigValueTag.advanced])
+    
+    @staticmethod
+    def get_moonshine_folder_config_value(is_hidden: bool = False) -> ConfigValue:
+        description = "The folder where Moonshine models are installed (where tiny/ and base/ folders exist)."
+        return ConfigValueString("moonshine_folder", "Moonshine Folder", description, "", is_hidden=is_hidden, tags=[ConfigValueTag.advanced])

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -88,6 +88,7 @@ class MantellaConfigValueDefinitionsNew:
         stt_category.add_config_value(STTDefinitions.get_stt_language_config_value())
         stt_category.add_config_value(STTDefinitions.get_stt_translate_config_value())
         stt_category.add_config_value(STTDefinitions.get_process_device_config_value())
+        stt_category.add_config_value(STTDefinitions.get_moonshine_folder_config_value(is_integrated))
         result.add_base_group(stt_category)
 
         vision_category = ConfigValueGroup("Vision", "Vision", "Vision settings.", on_value_change_callback)

--- a/src/stt.py
+++ b/src/stt.py
@@ -33,12 +33,16 @@ class Transcriber:
     CHUNK_DURATION = CHUNK_SIZE / SAMPLING_RATE  # Explicit calculation of chunk duration in seconds
     LOOKBACK_CHUNKS = 5  # Number of chunks to keep in buffer when not recording
     
+    @utils.time_it
     def __init__(self, config: ConfigLoader, stt_secret_key_file: str, secret_key_file: str):
         self.loglevel = 27
         self.language = config.stt_language
         self.task = "translate" if config.stt_translate == 1 else "transcribe"
         self.stt_service = config.stt_service
-        self.moonshine_model = config.moonshine_model
+        self.full_moonshine_model = config.moonshine_model
+        self.moonshine_model, self.moonshine_precision = self.full_moonshine_model.rsplit('/', 1)
+        self.moonshine_folder = config.moonshine_folder
+        self.moonshine_model_path = os.path.join(self.moonshine_folder, self.full_moonshine_model)
         self.whisper_model = config.whisper_model
         self.process_device = config.whisper_process_device
         self.listen_timeout = config.listen_timeout
@@ -47,7 +51,6 @@ class Transcriber:
         self.whisper_url = self.__get_endpoint(config.whisper_url)
         self.prompt = ''
         self.show_mic_warning = True
-        self.log_interim_transcriptions = False
         self.transcription_times = []
         self.proactive_mic_mode = config.proactive_mic_mode
         self.min_refresh_secs = config.min_refresh_secs # Minimum time between transcription updates
@@ -65,7 +68,7 @@ class Transcriber:
         self.__secret_key_file = secret_key_file
         self.__api_key: str | None = self.__get_api_key()
         self.__initial_client: OpenAI | None = None
-        if (self.__api_key) and ('openai' in self.whisper_url) and (self.external_whisper_service):
+        if (self.stt_service == 'whisper') and (self.__api_key) and ('openai' in self.whisper_url) and (self.external_whisper_service):
             self.__initial_client = self.__generate_sync_client() # initialize first client in advance to save time
 
         self.__ignore_list = ['', 'thank you for watching', 'thanks for watching', 'the transcript is from the', 'the', 'thank you very much', "thank you for watching and i'll see you in the next video", "we'll see you in the next video", 'see you next time']
@@ -81,10 +84,14 @@ class Transcriber:
         else:
             if self.language != 'en':
                 logging.warning(f"Selected language is '{self.language}', but Moonshine only supports English. Please change the selected speech-to-text model to Whisper in `Speech-to-Text`->`STT Service` in the Mantella UI")
-            self.transcribe_model = MoonshineOnnxModel(model_name=self.moonshine_model)
+            
+            if os.path.exists(f'{self.moonshine_model_path}/encoder_model.onnx'):
+                logging.log(self.loglevel, 'Loading local Moonshine model...')
+                self.transcribe_model = MoonshineOnnxModel(models_dir=self.moonshine_model_path, model_name=self.moonshine_model)
+            else:
+                logging.log(self.loglevel, 'Loading Moonshine model from Hugging Face...')
+                self.transcribe_model = MoonshineOnnxModel(model_name=self.moonshine_model, model_precision=self.moonshine_precision)
             self.tokenizer = load_tokenizer()
-            # Warm up the model
-            self._transcribe(np.zeros(self.SAMPLING_RATE, dtype=np.float32))
         
         # Initialize VAD
         self.vad_model = load_silero_vad(onnx=True)
@@ -190,9 +197,8 @@ If you would prefer to run speech-to-text locally, please ensure the `Speech-to-
             if max_transcription_time > self.min_refresh_secs:
                 logging.warning(f'Mic transcription took {round(max_transcription_time,3)} to process. To improve performance, try setting `Speech-to-Text`->`Refresh Frequency` to a value slightly higher than {round(max_transcription_time,3)} in the Mantella UI')
 
-        if (self.proactive_mic_mode) and (self.stt_service != 'moonshine' or self.log_interim_transcriptions): # Do not log when Moonshine calls its warmup transcription
+        if self.proactive_mic_mode:
             logging.log(self.loglevel, f'Interim transcription: {transcription}')
-        self.log_interim_transcriptions = True
         
         return transcription
 
@@ -294,7 +300,7 @@ If you would prefer to run speech-to-text locally, please ensure the `Speech-to-
                 # Get audio chunk and status from queue
                 chunk, status = self._audio_queue.get(timeout=0.1)
                 if status:
-                    logging.error(f"Processing audio error: {status}")
+                    logging.warning(f"Processing audio error: {status}")
                     continue
 
                 with self._lock:
@@ -369,7 +375,7 @@ If you would prefer to run speech-to-text locally, please ensure the `Speech-to-
         """Create callback for audio input stream."""
         def input_callback(indata, frames, time, status):
             if status:
-                logging.error(f"Audio input error: {status}")
+                logging.warning(f"Audio input error: {status}")
             # Store both data and status in queue
             q.put((indata.copy().flatten(), status))
         return input_callback


### PR DESCRIPTION
- Added ability to load Moonshine model from local folder
  - This folder is automatically set when Mantella.exe is run by the launcher
  - Otherwise, the folder can be manually set in the `Speech-to-Text`->`Moonshine Folder` setting in the UI. If set this way, this setting must point to a `moonshine` folder which contains two subfolders: `model name` and `model precision` (eg `/tiny/quantized/files.onnx`)
 - Updated Moonshine version to take advantage of quantized models