### PR TITLE
Added config values for LLM output parsing

### DIFF
--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 from typing import Any
-from src.config.definitions.llm_definitions import NarrationHandlingEnum, NarrationAndSpeechIndicatorsEnum
+from src.config.definitions.llm_definitions import NarrationHandlingEnum, NarrationIndicatorsEnum
 from src.conversation.action import action
 from src.config.config_values import ConfigValues
 from src.config.mantella_config_value_definitions_new import MantellaConfigValueDefinitionsNew
@@ -266,7 +266,7 @@ LLM parameter list must follow the Python dictionary format: https://www.w3schoo
             self.narration_end_indicators = self.__definitions.get_string_list_value("narration_end_indicators")
             self.speech_start_indicators = self.__definitions.get_string_list_value("speech_start_indicators")
             self.speech_end_indicators = self.__definitions.get_string_list_value("speech_end_indicators")
-            self.narration_indicators: NarrationAndSpeechIndicatorsEnum = self.__definitions.get_enum_value("narration_indicators", NarrationAndSpeechIndicatorsEnum)
+            self.narration_indicators: NarrationIndicatorsEnum = self.__definitions.get_enum_value("narration_indicators", NarrationIndicatorsEnum)
             
 
             self.remove_mei_folders = self.__definitions.get_bool_value("remove_mei_folders")

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 from typing import Any
+from src.config.definitions.llm_definitions import NarrationHandlingEnum, NarrationAndSpeechIndicatorsEnum
 from src.conversation.action import action
 from src.config.config_values import ConfigValues
 from src.config.mantella_config_value_definitions_new import MantellaConfigValueDefinitionsNew
@@ -259,8 +260,13 @@ LLM parameter list must follow the Python dictionary format: https://www.w3schoo
             # self.stop_llm_generation_on_assist_keyword: bool = self.__definitions.get_bool_value("stop_llm_generation_on_assist_keyword")
             # self.try_filter_narration: bool = self.__definitions.get_bool_value("try_filter_narration")
 
-            self.narration_handling = self.__definitions.get_string_value("narration_handling").strip().lower()
+            self.narration_handling: NarrationHandlingEnum = self.__definitions.get_enum_value("narration_handling", NarrationHandlingEnum)
             self.narrator_voice = self.__definitions.get_string_value("narrator_voice")
+            self.narration_start_indicators = self.__definitions.get_string_list_value("narration_start_indicators")
+            self.narration_end_indicators = self.__definitions.get_string_list_value("narration_end_indicators")
+            self.speech_start_indicators = self.__definitions.get_string_list_value("speech_start_indicators")
+            self.speech_end_indicators = self.__definitions.get_string_list_value("speech_end_indicators")
+            self.narration_indicators: NarrationAndSpeechIndicatorsEnum = self.__definitions.get_enum_value("narration_indicators", NarrationAndSpeechIndicatorsEnum)
             
 
             self.remove_mei_folders = self.__definitions.get_bool_value("remove_mei_folders")

--- a/src/config/definitions/llm_definitions.py
+++ b/src/config/definitions/llm_definitions.py
@@ -1,3 +1,5 @@
+from enum import Enum
+from src.config.types.config_value_multi_selection import ConfigValueMultiSelection
 from src.config.types.config_value import ConfigValue, ConfigValueTag
 from src.config.types.config_value_float import ConfigValueFloat
 from src.config.types.config_value_int import ConfigValueInt
@@ -5,6 +7,16 @@ from src.config.types.config_value_selection import ConfigValueSelection
 from src.config.types.config_value_string import ConfigValueString
 from src.config.types.config_value_bool import ConfigValueBool
 
+class NarrationHandlingEnum(Enum):
+    CUT_NARRATIONS = 0,
+    RESPECTIVE_CHARACTER_SPEAKS_NARRATION = 1,
+    USE_NARRATOR = 2,
+    DEACTIVATE_HANDLING_OF_NARRATIONS = 3
+
+class NarrationIndicatorsEnum(Enum):
+    PARANTHESES = 0,
+    ASTERISKS = 1,
+    BRACKETS = 2
 
 class LLMDefinitions:
     @staticmethod
@@ -46,12 +58,6 @@ class LLMDefinitions:
         description = "The maximum number of sentences returned by the LLM on each response. Lower this value to reduce waffling.\nNote: The setting 'Number Words TTS' in the Text-to-Speech tab takes precedence over this setting."
         return ConfigValueInt("max_response_sentences","Max Sentences per Response", description, 4, 1, 999, tags=[ConfigValueTag.share_row])
     
-    # @staticmethod
-    # def get_llm_custom_service_url_config_value() -> ConfigValue:
-    #     description = """If 'Custom' is selected for 'LLM Service' above, Mantella will connect to the URL below. 
-    #                     A custom LLM service is expected to provide an OpenAI API compatible endpoint."""
-    #     return ConfigValueString("llm_custom_service_url","LLM Custom Service URL",description, "http://127.0.0.1:5001/v1",tags=[ConfigValueTag.advanced])
-    
     @staticmethod
     def get_wait_time_buffer_config_value() -> ConfigValue:
         description = """Time to wait (in seconds) before generating the next voiceline.
@@ -59,28 +65,6 @@ class LLMDefinitions:
                         If you are noticing that some voicelines are not being said in-game, try increasing this buffer."""
         return ConfigValueFloat("wait_time_buffer","Wait Time Buffer",description, 0, -999, 999,tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
     
-    # @staticmethod
-    # def get_try_filter_narration() -> ConfigValue:
-    #     try_filter_narration_description = """If checked, sentences containing asterisks (*) will not be spoken aloud."""
-    #     return ConfigValueBool("try_filter_narration","Filter Narration",try_filter_narration_description,True,tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
-    
-    @staticmethod
-    def get_narration_handling() -> ConfigValue:
-        narration_handling_description = """How to handle narrations in the output of the LLM.
-                                            - Cut narrations: Removes narrations from the output.
-                                            - Respective character speaks its narrations: The currently active character will speak it's actions out aloud.
-                                            - Use narrator: Narrations will be spoken by a special narrator. The voice model can be set by the config value *Narrator voice* below.
-                                            
-                                            Note: The seperation of narration and speech is experimental and may not work if the LLM output is not formatted well."""
-        options = ["Cut narrations", "Respective character speaks its narrations", "Use narrator"]
-        return ConfigValueSelection("narration_handling","Narration Handling",narration_handling_description,options[0], options, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
-    
-    @staticmethod
-    def get_narrator_voice() -> ConfigValue:
-        description = """Which voice model to use if *Narration Handling* is set to 'Use narrator'.
-                        Must be a valid voice model from the current TTS. Same rules apply as for choosing a voice for the player."""
-        return ConfigValueString("narrator_voice","Narrator voice",description,"", tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
-
     @staticmethod
     def get_llm_params_config_value() -> ConfigValue:
         value = """{
@@ -92,9 +76,57 @@ class LLMDefinitions:
                         Note that available parameters can vary per LLM provider."""
         return ConfigValueString("llm_params", "Parameters", description, value, tags=[ConfigValueTag.advanced])
 
-    # @staticmethod
-    # def get_stop_llm_generation_on_assist_keyword() -> ConfigValue:
-    #     stop_llm_generation_on_assist_keyword_description = """Should the generation of the LLM be stopped if the word 'assist' is found?
-    #                                                             A lot of LLMs are trained to be virtual assistants use the word excessively.
-    #                                                             Default: Checked"""
-    #     return ConfigValueBool("stop_llm_generation_on_assist_keyword","Stop LLM generation if 'assist' keyword is found",stop_llm_generation_on_assist_keyword_description,True,tags=[ConfigValueTag.advanced])    
+    #LLM output parsing options
+
+    @staticmethod
+    def get_narration_handling() -> ConfigValue:
+        narration_handling_description = """How to handle narrations in the output of the LLM.
+                                            - Cut narrations: Removes narrations from the output.
+                                            - Respective character speaks its narrations: The currently active character will speak it's actions out aloud.
+                                            - Use narrator: Narrations will be spoken by a special narrator. The voice model can be set by the config value 'Narrator voice' below.
+                                            - Deactivate handling of narrations: Any narration or speech indicators will be ignored during parsing.
+                                            
+                                            Note: The seperation of narration and speech is experimental and may not work if the LLM output is not formatted well."""
+        options = ["Cut narrations", "Respective character speaks its narrations", "Use narrator", "Deactivate handling of narrations"]
+        enums: list[Enum] = [NarrationHandlingEnum.CUT_NARRATIONS, NarrationHandlingEnum.RESPECTIVE_CHARACTER_SPEAKS_NARRATION, NarrationHandlingEnum.USE_NARRATOR,  NarrationHandlingEnum.DEACTIVATE_HANDLING_OF_NARRATIONS]
+        return ConfigValueSelection("narration_handling","Narration Handling",narration_handling_description,options[0], options, corresponding_enums=enums, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+    
+    @staticmethod
+    def get_narrator_voice() -> ConfigValue:
+        description = """Which voice model to use if 'Narration Handling' is set to 'Use narrator'.
+                        Must be a valid voice model from the current TTS. Same rules apply as for choosing a voice for the player."""
+        return ConfigValueString("narrator_voice","Narrator voice",description,"", tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+    
+    @staticmethod
+    def get_narration_start_indicators() -> ConfigValue:
+        description = """List of characters used to identify the start of narrations in the LLM output."""
+        possible_characters = ["*","(","["]
+        return ConfigValueMultiSelection("narration_start_indicators","Narration start indicators",description,possible_characters, possible_characters, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+
+    @staticmethod
+    def get_narration_end_indicators() -> ConfigValue:
+        description = """List of characters used to identify the start of narrations in the LLM output."""
+        possible_characters = ["*",")","]"]
+        return ConfigValueMultiSelection("narration_end_indicators","Narration end indicators",description,possible_characters, possible_characters, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+
+    @staticmethod
+    def get_speech_start_indicators() -> ConfigValue:
+        description = """List of characters used to identify the end of narrations in the LLM output."""
+        possible_characters = ["\""]
+        return ConfigValueMultiSelection("speech_start_indicators","Speech start indicators",description,possible_characters, possible_characters, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+
+    @staticmethod
+    def get_speech_end_indicators() -> ConfigValue:
+        description = """List of characters used to identify the start of speech in the LLM output."""
+        possible_characters = ["\""]
+        return ConfigValueMultiSelection("speech_end_indicators","Speech end indicators",description,possible_characters, possible_characters, tags=[ConfigValueTag.advanced,ConfigValueTag.share_row])
+    
+    @staticmethod
+    def get_narration_indicators() -> ConfigValue:
+        description = """Which narration indicators to use for sentences identified as narrations.
+                        If sentences get marked as narrations and are not cut, they will be surrounded by these narration indicators the next time they are fed back to the LLM.
+                        This helps to keep the LLM consistent in its use of narration indicators."""
+        possible_characters = ["()","**","[]"]
+        enums: list[Enum] = [NarrationIndicatorsEnum.PARANTHESES, NarrationIndicatorsEnum.ASTERISKS, NarrationIndicatorsEnum.BRACKETS]
+        return ConfigValueSelection("narration_indicators","Narration indicators to use",description,possible_characters[0], possible_characters, corresponding_enums=enums, tags=[ConfigValueTag.advanced])
+

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -49,6 +49,11 @@ class MantellaConfigValueDefinitionsNew:
         # llm_category.add_config_value(LLMDefinitions.get_stop_llm_generation_on_assist_keyword())
         llm_category.add_config_value(LLMDefinitions.get_narration_handling())
         llm_category.add_config_value(LLMDefinitions.get_narrator_voice())
+        llm_category.add_config_value(LLMDefinitions.get_narration_start_indicators())
+        llm_category.add_config_value(LLMDefinitions.get_narration_end_indicators())
+        llm_category.add_config_value(LLMDefinitions.get_speech_start_indicators())
+        llm_category.add_config_value(LLMDefinitions.get_speech_end_indicators())
+        llm_category.add_config_value(LLMDefinitions.get_narration_indicators())
         result.add_base_group(llm_category)
 
         tts_category = ConfigValueGroup("TTS", "Text-to-Speech", "Settings for the TTS methods Mantella supports.", on_value_change_callback)

--- a/src/config/types/config_value_multi_selection.py
+++ b/src/config/types/config_value_multi_selection.py
@@ -22,7 +22,9 @@ class ConfigValueMultiSelection(ConfigValue[list[str]]):
     
     def parse(self, config_value: str) -> ConfigValueConstraintResult:
         try:
-            value_to_use: list[str] = list(x.strip() for x in config_value.split(","))
+            value_to_use: list[str] = []
+            if len(config_value) > 0:
+                value_to_use = list(x.strip() for x in config_value.split(","))
             result = self.does_value_cause_error(value_to_use)
             if result.is_success:
                 self.value = value_to_use

--- a/src/config/types/config_value_selection.py
+++ b/src/config/types/config_value_selection.py
@@ -1,12 +1,13 @@
+from enum import Enum
 from src.config.config_value_constraint import ConfigValueConstraint, ConfigValueConstraintResult
 from src.config.types.config_value_visitor import ConfigValueVisitor
 from src.config.types.config_value import ConfigValue, ConfigValueTag
 
-
 class ConfigValueSelection(ConfigValue[str]):
-    def __init__(self, identifier: str, name: str, description: str, default_value: str, options: list[str], allows_free_edit: bool = False, allows_values_not_in_options: bool = False, constraints: list[ConfigValueConstraint[str]] = [], is_hidden: bool = False, tags: list[ConfigValueTag] = []):
+    def __init__(self, identifier: str, name: str, description: str, default_value: str, options: list[str], corresponding_enums: list[Enum] | None = None, allows_free_edit: bool = False, allows_values_not_in_options: bool = False, constraints: list[ConfigValueConstraint[str]] = [], is_hidden: bool = False, tags: list[ConfigValueTag] = []):
         super().__init__(identifier, name, description, default_value, constraints, is_hidden, tags)
         self.__options: list[str] = options
+        self.__corresponding_enums: list[Enum] | None = corresponding_enums
         self.__allows_free_edit = allows_free_edit
         self.__allows_values_not_in_options = allows_values_not_in_options
 
@@ -15,12 +16,26 @@ class ConfigValueSelection(ConfigValue[str]):
         return self.__options
     
     @property
+    def has_corresponding_enums(self) -> bool:
+        return self.__corresponding_enums != None
+    
+    @property
     def allows_custom_value(self) -> bool:
         return self.__allows_free_edit
-    
+        
     @property
     def allows_values_not_in_options(self) -> bool:
         return self.__allows_values_not_in_options
+    
+    def get_corresponding_enum(self) -> Enum | None:
+        if not self.__corresponding_enums:
+            return None
+        else:
+            try:
+                index = self.__options.index(self.value)
+                return self.__corresponding_enums[index]
+            except:
+                return None
     
     def does_value_cause_error(self, value_to_check: str) -> ConfigValueConstraintResult:
         result = super().does_value_cause_error(value_to_check)

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -44,7 +44,7 @@ class conversation:
             self.__conversation_type: conversation_type = radiant(context_for_conversation.config)
         else:
             self.__conversation_type: conversation_type = pc_to_npc(context_for_conversation.config)        
-        self.__messages: message_thread = message_thread(None)
+        self.__messages: message_thread = message_thread(self.__context.config, None)
         self.__output_manager: ChatManager = output_manager
         self.__rememberer: remembering = rememberer
         self.__llm_client = llm_client
@@ -207,7 +207,7 @@ class conversation:
                 # otherwise the player could constantly speak over the NPC and never hear a response
                 self.__stt.stop_listening()
             
-            new_message: user_message = user_message(player_text, player_character.name, False)
+            new_message: user_message = user_message(self.__context.config, player_text, player_character.name, False)
             new_message.is_multi_npc_message = self.__context.npcs_in_conversation.contains_multiple_npcs()
             new_message = self.update_game_events(new_message)
             self.__messages.add_message(new_message)
@@ -277,7 +277,7 @@ class conversation:
 
             new_prompt = self.__conversation_type.generate_prompt(self.__context)        
             if len(self.__messages) == 0:
-                self.__messages: message_thread = message_thread(new_prompt)
+                self.__messages: message_thread = message_thread(self.__context.config, new_prompt)
             else:
                 self.__conversation_type.adjust_existing_message_thread(new_prompt, self.__messages)
                 self.__messages.reload_message_thread(new_prompt, self.__llm_client.is_too_long, self.TOKEN_LIMIT_RELOAD_MESSAGES)
@@ -315,7 +315,7 @@ class conversation:
         if not next_sentence.is_system_generated_sentence and not next_sentence.speaker.is_player_character:
             last_message = self.__messages.get_last_message()
             if not isinstance(last_message, assistant_message):
-                last_message = assistant_message()
+                last_message = assistant_message(self.__context.config)
                 last_message.is_multi_npc_message = self.__context.npcs_in_conversation.contains_multiple_npcs()
                 self.__messages.add_message(last_message)
             last_message.add_sentence(next_sentence)

--- a/src/conversation/conversation_type.py
+++ b/src/conversation/conversation_type.py
@@ -83,7 +83,7 @@ class pc_to_npc(conversation_type):
             if player_character:
                 for actor in context_for_conversation.npcs_in_conversation.get_all_characters():
                     if not actor.is_player_character:
-                        message = user_message(f"{context_for_conversation.language['hello']} {actor.name}.", player_character.name, True)
+                        message = user_message(context_for_conversation.config, f"{context_for_conversation.language['hello']} {actor.name}.", player_character.name, True)
                         message.is_multi_npc_message = False
                         return message
             return None
@@ -129,7 +129,7 @@ class radiant(conversation_type):
             text = self.__user_end_prompt
         else:
             return None
-        reply = user_message(text, "", True)
+        reply = user_message(context_for_conversation.config, text, "", True)
         reply.is_multi_npc_message = False # Don't flag these as multi-npc messages. Don't want a 'Player:' in front of the instruction messages
         return reply
     

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Hashable
 import regex
+from src.config.definitions.llm_definitions import NarrationHandlingEnum
 from src.games.equipment import Equipment, EquipmentItem
 from src.games.external_character_info import external_character_info
 from src.games.gameable import gameable
@@ -34,7 +35,7 @@ class GameStateManager:
         self.__language_info: dict[Hashable, str] = language_info 
         self.__client: LLMClient = client
         self.__chat_manager: ChatManager = chat_manager
-        self.__rememberer: remembering = summaries(game, config.memory_prompt, config.resummarize_prompt, client, language_info['language'])
+        self.__rememberer: remembering = summaries(game, config, client, language_info['language'])
         self.__talk: conversation | None = None
         self.__mic_input: bool = False
         self.__mic_ptt: bool = False # push-to-talk
@@ -43,7 +44,7 @@ class GameStateManager:
         self.__stt: Transcriber | None = None
         self.__first_line: bool = True
         self.__automatic_greeting: bool = config.automatic_greeting
-        self.__conv_has_narrator: bool = config.narration_handling == "use narrator"
+        self.__conv_has_narrator: bool = config.narration_handling == NarrationHandlingEnum.USE_NARRATOR
 
     ###### react to calls from the game #######
     @utils.time_it
@@ -71,7 +72,7 @@ class GameStateManager:
             
         return {
             comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTTYPE_STARTCONVERSATIONCOMPLETED,
-            comm_consts.KEY_STARTCONVERSATION_USENARRATOR: self.__config.narration_handling == "use narrator"}
+            comm_consts.KEY_STARTCONVERSATION_USENARRATOR: self.__conv_has_narrator}
         
     
     @utils.time_it

--- a/src/llm/image_client.py
+++ b/src/llm/image_client.py
@@ -12,6 +12,7 @@ class ImageClient(ClientBase):
     '''
     @utils.time_it
     def __init__(self, config: ConfigLoader, secret_key_file: str, image_secret_key_file: str) -> None:
+        self.__config = config    
         self.__custom_vision_model: bool = config.custom_vision_model
 
         if self.__custom_vision_model: # if using a custom model for vision, load these custom config values
@@ -76,7 +77,7 @@ class ImageClient(ClientBase):
                 vision_prompt = f"{self.__vision_prompt}\n{vision_hints}"
             else:
                 vision_prompt = self.__vision_prompt
-            image_msg_instance = image_message(image, vision_prompt, self.__detail, True)
+            image_msg_instance = image_message(self.__config, image, vision_prompt, self.__detail, True)
             image_transcription = self.request_call(image_msg_instance)
             if image_transcription:
                 last_punctuation = max(image_transcription.rfind(p) for p in self.__end_of_sentence_chars)

--- a/src/llm/message_thread.py
+++ b/src/llm/message_thread.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from src.config.config_loader import ConfigLoader
 from src.llm.messages import message, system_message, user_message, assistant_message, image_message, image_description_message
 from typing import Callable
 from openai.types.chat import ChatCompletionMessageParam
@@ -8,12 +9,13 @@ class message_thread():
     """A thread of messages consisting of system-, user- and assistant-messages.
     Central place for adding new messages to the thread and manipulating the existing ones
     """
-    def __init__(self, initial_system_message: str | system_message | None) -> None:
+    def __init__(self, config: ConfigLoader, initial_system_message: str | system_message | None) -> None:
         self.__messages: list[message] = []
+        self.__config = config
         if not initial_system_message:
             return
         if isinstance(initial_system_message, str):
-            initial_system_message = system_message(initial_system_message)        
+            initial_system_message = system_message(initial_system_message, config)
         self.__messages.append(initial_system_message)
     
     def __len__(self) -> int:
@@ -76,7 +78,7 @@ class message_thread():
             last_messages_to_keep (int): how many of the last messages to keep
         """
         result: list[message] = []
-        result.append(system_message(new_prompt))
+        result.append(system_message(new_prompt, self.__config))
         messages_to_keep: list[message]  = []
         for talk_message in reversed(self.get_talk_only()):
             messages_to_keep.append(talk_message)

--- a/src/llm/output/narration_parser.py
+++ b/src/llm/output/narration_parser.py
@@ -10,14 +10,24 @@ class narration_parser(output_parser):
                 speech_start_chars: list[str] = ["\""], speech_end_chars: list[str] = ["\""]) -> None:
         super().__init__()
         base_regex_def = "^.*?[{chars}]"
+        never_match_anything_regex = re.compile("\\b\\B")
         self.__narration_start_chars: list[str] = narration_start_chars
         self.__narration_end_chars: list[str] = narration_end_chars
-        self.__start_narration_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(narration_start_chars))) #Should look like ^.*?[\*\(\[]
-        self.__end_narration_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(narration_end_chars))) #Should look like ^.*?[\*\)\]]
+        if len(narration_start_chars) > 0 and len(narration_end_chars) > 0:
+            self.__start_narration_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(narration_start_chars))) #Should look like ^.*?[\*\(\[]
+            self.__end_narration_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(narration_end_chars))) #Should look like ^.*?[\*\)\]]
+        else:
+            self.__start_narration_reg = never_match_anything_regex
+            self.__end_narration_reg = never_match_anything_regex
+        
         self.__speech_start_chars: list[str] = speech_start_chars
         self.__speech_end_chars: list[str] = speech_end_chars
-        self.__start_speech_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(speech_start_chars))) #Should look like ^.*?[\*\(\[]
-        self.__end_speech_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(speech_end_chars))) #Should look like ^.*?[\*\)\]]
+        if len(speech_start_chars) > 0 and len(speech_end_chars) > 0:
+            self.__start_speech_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(speech_start_chars))) #Should look like ^.*?[\*\(\[]
+            self.__end_speech_reg = re.compile(base_regex_def.format(chars = "\\" + "\\".join(speech_end_chars))) #Should look like ^.*?[\*\)\]]
+        else:
+            self.__start_speech_reg = never_match_anything_regex
+            self.__end_speech_reg = never_match_anything_regex
 
     def cut_sentence(self, output: str, current_settings: sentence_generation_settings) -> tuple[sentence_content | None, str]:
         output = output.lstrip()


### PR DESCRIPTION
Added config values for LLM output parsing:
- `narration_start_indicators`
- `narration_end_indicators`
- `speech_start_indicators`
- `speech_end_indicators`
- `narration_indicators`
- fourth option for `narration_handling` -> Ignore narration changes entirely. Everything is speech.

Added `corresponding_enums` parameter to `ConfigValueSelection`. This allows to directly work with enums instead of the strings within the software. Saving and loading is still done using strings.

Fixed bug in `ConfigValueMultiSelection` that would not load empty strings as values from the `config.ini`. These are now treated as empty lists.