### PR TITLE
Dont generate responses when no npc is in range

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // created by vscode papyrus-lang papyrus.skyrimSpecialEdition.generateProject
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Mantella",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "C:\\MadGod\\modlist\\mods\\Mantella-0.13\\SKSE\\Plugins\\MantellaSoftware\\main.py",
+            "console": "integratedTerminal",
+            "python": "C:\\MadGod\\modlist\\mods\\Mantella-0.13\\SKSE\\Plugins\\MantellaSoftware\\MantellaEnv\\Scripts\\python.exe",
+            "cwd": "C:\\MadGod\\modlist\\mods\\Mantella-0.13\\SKSE\\Plugins\\MantellaSoftware"
+        },        
+        {
+            "name": "Skyrim SE",
+            "type": "papyrus",
+            "request": "attach",
+            "game": "skyrimSpecialEdition"
+        }
+    ]
+}

--- a/src/character_manager.py
+++ b/src/character_manager.py
@@ -4,7 +4,7 @@ from src.games.equipment import Equipment
 class Character:
     """Representation of a character in the game
     """
-    def __init__(self, base_id: str, ref_id: str,  name: str, gender: int, race: str, is_player_character: bool, bio: str, is_in_combat: bool, is_enemy: bool, relationship_rank: int, is_generic_npc: bool, ingame_voice_model:str, tts_voice_model: str, csv_in_game_voice_model: str, advanced_voice_model: str, voice_accent: str, equipment:Equipment, custom_character_values: dict[str, Any]):
+    def __init__(self, base_id: str, ref_id: str,  name: str, gender: int, race: str, is_player_character: bool, bio: str, is_in_combat: bool, is_outside_talking_range:bool, is_enemy: bool, relationship_rank: int, is_generic_npc: bool, ingame_voice_model:str, tts_voice_model: str, csv_in_game_voice_model: str, advanced_voice_model: str, voice_accent: str, equipment:Equipment, custom_character_values: dict[str, Any]):
         self.__base_id: str = base_id
         self.__ref_id: str = ref_id
         self.__name: str = name
@@ -13,6 +13,7 @@ class Character:
         self.__is_player_character: bool = is_player_character
         self.__bio: str = bio
         self.__is_in_combat: bool = is_in_combat
+        self.__is_outside_talking_range: bool = is_outside_talking_range
         self.__is_enemy: bool = is_enemy
         self.__relationship_rank: int = relationship_rank
         self.__is_generic_npc: bool = is_generic_npc
@@ -99,6 +100,14 @@ class Character:
     @is_in_combat.setter
     def is_in_combat(self, value: bool):
         self.__is_in_combat = value
+        
+    @property
+    def is_outside_talking_range(self) -> bool:
+        return self.__is_outside_talking_range
+    
+    @is_outside_talking_range.setter
+    def is_outside_talking_range(self, value: bool):
+        self.__is_outside_talking_range = value
     
     @property
     def is_enemy(self) -> bool:

--- a/src/character_manager.py
+++ b/src/character_manager.py
@@ -103,6 +103,8 @@ class Character:
         
     @property
     def is_outside_talking_range(self) -> bool:
+        if(self.is_player_character):
+            return False
         return self.__is_outside_talking_range
     
     @is_outside_talking_range.setter

--- a/src/characters_manager.py
+++ b/src/characters_manager.py
@@ -37,6 +37,7 @@ class Characters:
         else: #Is update: update transient stats + custom values
             self.__active_characters[new_character.name].is_enemy = new_character.is_enemy
             self.__active_characters[new_character.name].is_in_combat = new_character.is_in_combat
+            self.__active_characters[new_character.name].is_outside_talking_range = new_character.is_outside_talking_range
             self.__active_characters[new_character.name].relationship_rank = new_character.relationship_rank
             self.__active_characters[new_character.name].custom_character_values = new_character.custom_character_values
     

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -212,6 +212,16 @@ class context:
                 self.__ingame_events.append(f"{name} is now in combat!")
             else:
                 self.__ingame_events.append(f"{name} is no longer in combat.")
+        
+        # Npc left / entered talking range in multipi-npc conversation
+        if current_stats.is_outside_talking_range != npc.is_outside_talking_range and not npc.is_player_character:
+            isMultiNpcsConversation = self.__npcs_in_conversation.contains_multiple_npcs() and self.__npcs_in_conversation.contains_player_character()
+            if isMultiNpcsConversation:
+                if npc.is_outside_talking_range:        
+                    self.__ingame_events.append(f"{npc.name} is too far away to talk. They can no longer respond")
+                else:
+                    self.__ingame_events.append(f"{npc.name} is now close enough to talk. They can respond again")
+        
         #update custom  values
         try:
             if (current_stats.get_custom_character_value("mantella_actor_pos_x") is not None and

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -33,7 +33,7 @@ class context:
         self.__vision_hints: str = ''
         self.__have_actors_changed: bool = False
         self.__game = config.game
-
+        self.__is_end_sequence_initiated = False
         self.__prev_location: str | None = None
         if self.__game == "Fallout4" or self.__game == "Fallout4VR":
             self.__location: str = 'the Commonwealth'
@@ -83,6 +83,14 @@ class context:
     @have_actors_changed.setter
     def have_actors_changed(self, value: bool):
         self.__have_actors_changed = value
+
+    @property
+    def is_end_sequence_initiated(self) -> bool:
+        return self.__is_end_sequence_initiated
+    
+    @is_end_sequence_initiated.setter
+    def is_end_sequence_initiated(self, value: bool):
+        self.__is_end_sequence_initiated = value
 
     @property
     def vision_hints(self) -> dict[Hashable, str]:

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -146,10 +146,7 @@ class context:
         for npc in self.__npcs_in_conversation.get_all_characters():
             if not npc in new_list_of_npcs:
                 removed_npcs.append(npc)
-                self.__remove_character(npc)
-        
-        if len(added_npcs) > 0:
-            self.add_out_of_range_events()      
+                self.__remove_character(npc) 
         
         return add_or_update_result(added_npcs, removed_npcs)
     
@@ -225,10 +222,6 @@ class context:
             else:
                 self.__ingame_events.append(f"{name} is no longer in combat.")
         
-        # Npc left / entered talking range in multipi-npc conversation
-        if current_stats.is_outside_talking_range != npc.is_outside_talking_range and not npc.is_player_character:
-            self.may_add_talking_range_change_events()
-        
         #update custom  values
         try:
             if (current_stats.get_custom_character_value("mantella_actor_pos_x") is not None and
@@ -258,29 +251,6 @@ class context:
             if current_stats.relationship_rank != npc.relationship_rank:
                 trust = self.__get_trust(npc)
                 self.__ingame_events.append(f"{player_name} is now {trust} to {npc.name}.")
-    
-    @utils.time_it
-    def may_add_talking_range_change_events(self):
-        isMultiNpcsConversation = self.__npcs_in_conversation.contains_multiple_npcs() and self.__npcs_in_conversation.contains_player_character()  
-        for npc in self.__npcs_in_conversation.get_all_characters():
-            if npc.is_outside_talking_range:        
-                logging.info(f"{npc.name} is too far away to talk. They can no longer respond")
-            else:
-                logging.info(f"{npc.name} is now close enough to talk. They can respond again") 
-        
-            if isMultiNpcsConversation:
-                if npc.is_outside_talking_range:        
-                    self.__ingame_events.append(f"{npc.name} is too far away to talk. They can no longer respond") 
-                else:
-                    self.__ingame_events.append(f"{npc.name} is now close enough to talk. They can respond again")
-    @utils.time_it
-    def add_out_of_range_events(self):
-        # When a 1-1 conversation becomes a multi-npc conversation, we need to let the model know who can speak
-        isMultiNpcsConversation = self.__npcs_in_conversation.contains_multiple_npcs() and self.__npcs_in_conversation.contains_player_character()  
-        for npc in self.__npcs_in_conversation.get_all_characters():      
-            if isMultiNpcsConversation:
-                if npc.is_outside_talking_range:        
-                    self.__ingame_events.append(f"{npc.name} is too far away to talk. They can no longer respond") 
     
     @staticmethod
     def format_listing(listing: list[str]) -> str:

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -215,10 +215,15 @@ class context:
         
         # Npc left / entered talking range in multipi-npc conversation
         if current_stats.is_outside_talking_range != npc.is_outside_talking_range and not npc.is_player_character:
-            isMultiNpcsConversation = self.__npcs_in_conversation.contains_multiple_npcs() and self.__npcs_in_conversation.contains_player_character()
+            isMultiNpcsConversation = self.__npcs_in_conversation.contains_multiple_npcs() and self.__npcs_in_conversation.contains_player_character()  
+            if npc.is_outside_talking_range:        
+                logging.info(f"{npc.name} is too far away to talk. They can no longer respond")
+            else:
+                logging.info(f"{npc.name} is now close enough to talk. They can respond again") 
+        
             if isMultiNpcsConversation:
                 if npc.is_outside_talking_range:        
-                    self.__ingame_events.append(f"{npc.name} is too far away to talk. They can no longer respond")
+                    self.__ingame_events.append(f"{npc.name} is too far away to talk. They can no longer respond") 
                 else:
                     self.__ingame_events.append(f"{npc.name} is now close enough to talk. They can respond again")
         

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -194,7 +194,7 @@ class conversation:
                 
                 # Start tracking how long it has taken to receive a player response
                 input_wait_start_time = time.time()
-                while not player_text:
+                while not player_text and not self.can_any_npc_reply():
                     player_text = self.__stt.get_latest_transcription()
                 if time.time() - input_wait_start_time >= self.__events_refresh_time:
                     # If too much time has passed, in-game events need to be updated
@@ -243,6 +243,14 @@ class conversation:
                 player_character_voiced_sentence = sentence(player_message_content, "" , 2.0)
 
         return player_character_voiced_sentence
+
+    @utils.time_it
+    def can_any_npc_reply(self) -> bool:
+        if self.__context.npcs_in_conversation.contains_player_character():
+            for npc in self.__context.npcs_in_conversation.get_all_characters():
+                if not npc.is_player_character and not npc.is_outside_talking_range:
+                    return True
+        return True  
 
     @utils.time_it
     def update_context(self, location: str | None, time: int, custom_ingame_events: list[str], weather: str, custom_context_values: dict[str, Any]):

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -314,9 +314,10 @@ class conversation:
     
     def __may_add_out_of_range_event(self, message:user_message):
         if self.__context.npcs_in_conversation.contains_multiple_npcs() and any([npc.is_outside_talking_range for npc in self.__context.npcs_in_conversation.get_all_characters()]):
-            out_of_range_npcs = ",".join([npc.name for npc in self.__context.npcs_in_conversation.get_all_characters() if npc.is_outside_talking_range])
+            out_of_range_npcs = [npc.name for npc in self.__context.npcs_in_conversation.get_all_characters() if npc.is_outside_talking_range]
+            npc_names = ", ".join(out_of_range_npcs)
             is_are = "is" if len(out_of_range_npcs) == 1 else "are"
-            message.add_event([f"{out_of_range_npcs} {is_are} too far away and cannot reply"])
+            message.add_event([f"{npc_names} {is_are} too far away and cannot reply"])
             
     @utils.time_it
     def update_game_events(self, message: user_message) -> user_message:

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -221,8 +221,11 @@ class conversation:
         elif self.__has_conversation_ended(text):
             new_message.is_system_generated_message = True # Flag message containing goodbye as a system message to exclude from summary
             self.initiate_end_sequence()
-        else:
+        else: #if self.can_any_npc_reply():
             self.__start_generating_npc_sentences()
+
+        if not self.can_any_npc_reply():
+            logging.info("No NPC is in range to reply")
 
         return player_text, events_need_updating, player_voiceline
 
@@ -250,7 +253,7 @@ class conversation:
             for npc in self.__context.npcs_in_conversation.get_all_characters():
                 if not npc.is_player_character and not npc.is_outside_talking_range:
                     return True
-        return True  
+        return False  
 
     @utils.time_it
     def update_context(self, location: str | None, time: int, custom_ingame_events: list[str], weather: str, custom_context_values: dict[str, Any]):
@@ -347,6 +350,7 @@ class conversation:
                 if goodbye_sentence:
                     goodbye_sentence.actions.append(comm_consts.ACTION_ENDCONVERSATION)
                     self.__sentences.put(goodbye_sentence)
+                    self.context.is_end_sequence_initiated = True
                     
     @utils.time_it
     def contains_character(self, ref_id: str) -> bool:

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -194,7 +194,7 @@ class conversation:
                 
                 # Start tracking how long it has taken to receive a player response
                 input_wait_start_time = time.time()
-                while not player_text and not self.can_any_npc_reply():
+                while not player_text:
                     player_text = self.__stt.get_latest_transcription()
                 if time.time() - input_wait_start_time >= self.__events_refresh_time:
                     # If too much time has passed, in-game events need to be updated

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -246,6 +246,8 @@ class conversation:
 
         return player_text, events_need_updating, player_voiceline
 
+
+
     def __get_mic_prompt(self):
         mic_prompt = f"This is a conversation with {self.__context.get_character_names_as_text(False)} in {self.__context.location}."
         #logging.log(23, f'Context for mic transcription: {mic_prompt}')
@@ -309,7 +311,13 @@ class conversation:
             else:
                 self.__conversation_type.adjust_existing_message_thread(new_prompt, self.__messages)
                 self.__messages.reload_message_thread(new_prompt, self.__llm_client.is_too_long, self.TOKEN_LIMIT_RELOAD_MESSAGES)
-
+    
+    def __may_add_out_of_range_event(self, message:user_message):
+        if self.__context.npcs_in_conversation.contains_multiple_npcs() and any([npc.is_outside_talking_range for npc in self.__context.npcs_in_conversation.get_all_characters()]):
+            out_of_range_npcs = ",".join([npc.name for npc in self.__context.npcs_in_conversation.get_all_characters() if npc.is_outside_talking_range])
+            is_are = "is" if len(out_of_range_npcs) == 1 else "are"
+            message.add_event([f"{out_of_range_npcs} {is_are} too far away and cannot reply"])
+            
     @utils.time_it
     def update_game_events(self, message: user_message) -> user_message:
         """Add in-game events to player's response"""
@@ -318,6 +326,7 @@ class conversation:
         if self.__is_player_interrupting:
             all_ingame_events.append('Interrupting...')
             self.__is_player_interrupting = False
+        self.__may_add_out_of_range_event(message)
         max_events = min(len(all_ingame_events) ,self.__context.config.max_count_events)
         message.add_event(all_ingame_events[-max_events:])
         self.__context.clear_context_ingame_events()        

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -238,6 +238,7 @@ class GameStateManager:
             actor_voice_model: str = str(json[comm_consts.KEY_ACTOR_VOICETYPE])
             ingame_voice_model: str = actor_voice_model.split('<')[1].split(' ')[0]
             is_in_combat: bool = bool(json[comm_consts.KEY_ACTOR_ISINCOMBAT])
+            is_outside_talking_range: bool = bool(json[comm_consts.KEY_ACTOR_ISOUTSIDETALKINGRANGE])
             is_enemy: bool = bool(json[comm_consts.KEY_ACTOR_ISENEMY])
             relationship_rank: int = int(json[comm_consts.KEY_ACTOR_RELATIONSHIPRANK])
             custom_values: dict[str, Any] = {}
@@ -290,6 +291,7 @@ class GameStateManager:
                             is_player_character,
                             bio,
                             is_in_combat,
+                            is_outside_talking_range,
                             is_enemy,
                             relationship_rank,
                             is_generic_npc,

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -122,7 +122,10 @@ class GameStateManager:
         updated_player_text, update_events, player_spoken_sentence = self.__talk.process_player_input(player_text)
         if update_events:
             return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REQUESTTYPE_TTS, comm_consts.KEY_TRANSCRIBE: updated_player_text}
-
+      
+       # if not self.__talk.can_any_npc_reply() and not context.is_end_sequence_initiated:
+       #     return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTYPE_PLAYERTALK}   
+        
         cleaned_player_text = utils.clean_text(updated_player_text)
         npcs_in_conversation = self.__talk.context.npcs_in_conversation
         if not npcs_in_conversation.contains_multiple_npcs(): # actions are only enabled in 1-1 conversations
@@ -135,9 +138,9 @@ class GameStateManager:
                                 'mantella_actor_actions': [action.identifier],
                                 }
                             }
-        
+      
         # if the player response is not an action command, return a regular player reply type
-        if player_spoken_sentence and self.__talk.can_any_npc_reply():
+        if player_spoken_sentence: 
             topicInfoID: int = int(input_json.get(comm_consts.KEY_CONTINUECONVERSATION_TOPICINFOFILE,1))
             self.__game.prepare_sentence_for_game(player_spoken_sentence, self.__talk.context, self.__config, topicInfoID, self.__first_line)
             self.__first_line = False

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -122,9 +122,9 @@ class GameStateManager:
         updated_player_text, update_events, player_spoken_sentence = self.__talk.process_player_input(player_text)
         if update_events:
             return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REQUESTTYPE_TTS, comm_consts.KEY_TRANSCRIBE: updated_player_text}
-      
-       # if not self.__talk.can_any_npc_reply() and not context.is_end_sequence_initiated:
-       #     return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTYPE_PLAYERTALK}   
+        canReply =  self.__talk.can_any_npc_reply()
+        if not canReply and not self.__talk.context.is_end_sequence_initiated:
+            return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTYPE_PLAYERTALK}   
         
         cleaned_player_text = utils.clean_text(updated_player_text)
         npcs_in_conversation = self.__talk.context.npcs_in_conversation

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -137,7 +137,7 @@ class GameStateManager:
                             }
         
         # if the player response is not an action command, return a regular player reply type
-        if player_spoken_sentence:
+        if player_spoken_sentence and self.__talk.can_any_npc_reply():
             topicInfoID: int = int(input_json.get(comm_consts.KEY_CONTINUECONVERSATION_TOPICINFOFILE,1))
             self.__game.prepare_sentence_for_game(player_spoken_sentence, self.__talk.context, self.__config, topicInfoID, self.__first_line)
             self.__first_line = False

--- a/src/http/communication_constants.py
+++ b/src/http/communication_constants.py
@@ -43,6 +43,7 @@ class communication_constants:
     KEY_ACTOR_RELATIONSHIPRANK: str = PREFIX + "actor_relationshiprank"
     KEY_ACTOR_VOICETYPE: str = PREFIX + "actor_voicetype"
     KEY_ACTOR_ISINCOMBAT: str = PREFIX + "actor_is_in_combat"
+    KEY_ACTOR_ISOUTSIDETALKINGRANGE: str = PREFIX + "actor_is_outside_talking_range"
     KEY_ACTOR_ISENEMY: str = PREFIX + "actor_is_enemy"
     KEY_ACTOR_CUSTOMVALUES: str = PREFIX + "actor_custom_values"
     KEY_ACTOR_EQUIPMENT: str = PREFIX + "equipment"


### PR DESCRIPTION
Checks the distance of each participant during a conversation, prevents them from speaking if they are too far away
There are two modes for this: 
 - If there is at least one npc in range to talk, an event gets added about who is too far away & cant reply
 - If all are too far away, the players input is not sent to the llm at all

This is done by sending a bool `KEY_ACTOR_ISOUTSIDETALKINGRANGE` along for each npc in the conversation. 

Additionally, there is an option to remove npcs from conversation if they get even further away. This will not remove npcs when there is only one left (It wont end the conversation)

MCM Options added:
- A bool wether to remove far away npcs
- A distance threshold for removal
- A distance threshold for silencing

