### PR TITLE
Add skyrim whisper model to selection dialog

### DIFF
--- a/src/config/definitions/stt_definitions.py
+++ b/src/config/definitions/stt_definitions.py
@@ -79,7 +79,8 @@ class STTDefinitions:
                         See here for a comparison of languages and their Whisper performance: 
                         https://github.com/openai/whisper#available-models-and-languages
                         
-                        skyrim-whisper-base.en is the base.en, trained on Skyrim dialogue. It is more accurate in transcribing more prominent NPCs and Locations of Skyrim"""
+                        faster-skyrim-whisper-base.en is trained on Skyrim dialogue. It is more accurate in transcribing Skyrim names and locations:
+                        https://github.com/mikastamm/skyrim-whisper-base.en"""
         options = ["tiny", "tiny.en", 
                    "base", "base.en", "Numbat/faster-skyrim-whisper-base.en",
                    "small", "small.en", "distil-small.en", 


### PR DESCRIPTION
Adds my finetune of whisper-base.en to the whisper model selection. Works about as well as whisper-base.en, but is much better at correctly transcribing Skyrim Names and Locations

For more info see: https://github.com/mikastamm/skyrim-whisper-base.en