### PR TITLE
Fix: set LipGenerator.exe working directory to temp voiceline path.

### DIFF
--- a/src/tts/ttsable.py
+++ b/src/tts/ttsable.py
@@ -196,14 +196,14 @@ class ttsable(ABC):
 
                 #Using subprocess.run to retrieve the exit code
                 args: str = f'"{LipGen_path}" "{wav_file}" "{voiceline}" -Language:{language_parm} -Automated'
-                run_result: subprocess.CompletedProcess = subprocess.run(args, cwd=facefx_path, stderr=DEVNULL, stdout=DEVNULL,
+                run_result: subprocess.CompletedProcess = subprocess.run(args, cwd=self._voiceline_folder, stderr=DEVNULL, stdout=DEVNULL,
                                                                          creationflags=subprocess.CREATE_NO_WINDOW)
                 if run_result.returncode != 0 and len(voiceline) > 11 :
                     #Very short sentences sometimes fail to generate a .lip file, so skip warning
                     logging.warning(f'Lipgen returned {run_result.returncode}')
             else:
                 if not self.__has_lipgen_warning_happened:
-                    logging.warning('Could not find LipGenerator.exe. Please install or update the Creation Kit from Steam for faster lip sync generation')
+                    logging.warning(f'Could not find {LipGen_path}. Please install or update the Creation Kit from Steam for faster lip sync generation')
                     self.__has_lipgen_warning_happened = True
                 # Fall back to using FaceFXWrapper if LipGen not detected
                 face_wrapper_executable: Path = Path(self._facefx_path) / "FaceFXWrapper.exe"
@@ -242,13 +242,13 @@ class ttsable(ABC):
 
             if os.path.exists(LipFuz_path):
                 args: str = f'"{LipFuz_path}" -s "{self._voiceline_folder}" -d "{self._voiceline_folder}" -a wav --norec'
-                run_result: subprocess.CompletedProcess = subprocess.run(args, cwd=facefx_path, stdout=DEVNULL, stderr=DEVNULL,
+                run_result: subprocess.CompletedProcess = subprocess.run(args, cwd=self._voiceline_folder, stdout=DEVNULL, stderr=DEVNULL,
                                                                          creationflags=subprocess.CREATE_NO_WINDOW)
                 if run_result.returncode != 0:
                     logging.warning(f'LipFuzer returned {run_result.returncode}')
             else:
                 #Fall back to using Fuz_extractor and xWMAencode if LipFuzer not found
-                logging.warning('Could not find LipFuzer.exe: please install or update the creation kit from Steam')
+                logging.warning(f'Could not find {LipFuz_path}: please install or update the creation kit from Steam')
                 fuz_extractor_executable = Path(facefx_path) / "Fuz_extractor.exe"
                 if not fuz_extractor_executable.exists():
                     logging.error(f'Could not find Fuz_extractor.exe in "{facefx_path}" with which to create a fuz file, download it from: https://www.nexusmods.com/skyrimspecialedition/mods/55605')


### PR DESCRIPTION
Changed error message to indicate full path of LipGenerator.exe if not found.
