### PR TITLE
Support LLM selection for each npc

### DIFF
--- a/src/character_manager.py
+++ b/src/character_manager.py
@@ -4,7 +4,7 @@ from src.games.equipment import Equipment
 class Character:
     """Representation of a character in the game
     """
-    def __init__(self, base_id: str, ref_id: str,  name: str, gender: int, race: str, is_player_character: bool, bio: str, is_in_combat: bool, is_enemy: bool, relationship_rank: int, is_generic_npc: bool, ingame_voice_model:str, tts_voice_model: str, csv_in_game_voice_model: str, advanced_voice_model: str, voice_accent: str, equipment:Equipment, custom_character_values: dict[str, Any]):
+    def __init__(self, base_id: str, ref_id: str,  name: str, gender: int, race: str, is_player_character: bool, bio: str, is_in_combat: bool, is_enemy: bool, relationship_rank: int, is_generic_npc: bool, ingame_voice_model:str, tts_voice_model: str, csv_in_game_voice_model: str, advanced_voice_model: str, voice_accent: str, equipment:Equipment, custom_character_values: dict[str, Any], llm_openrouter_model: str = ""):
         self.__base_id: str = base_id
         self.__ref_id: str = ref_id
         self.__name: str = name
@@ -23,6 +23,7 @@ class Character:
         self.__voice_accent = voice_accent #info.get('voice_accent', None)
         self.__equipment = equipment
         self.__custom_character_values: dict[str, Any] = custom_character_values
+        self.__llm_openrouter_model: str = llm_openrouter_model
 
     @property
     def base_id(self) -> str:
@@ -175,6 +176,14 @@ class Character:
     @property
     def equipment(self) -> Equipment:
         return self.__equipment
+
+    @property
+    def llm_openrouter_model(self) -> str:
+        return self.__llm_openrouter_model
+    
+    @llm_openrouter_model.setter
+    def llm_openrouter_model(self, value: str):
+        self.__llm_openrouter_model = value
 
     def get_custom_character_value(self, key: str) -> Any:
         if self.__custom_character_values.__contains__(key):

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -272,6 +272,7 @@ LLM parameter list must follow the Python dictionary format: https://www.w3schoo
 
             #Conversation
             self.automatic_greeting = self.__definitions.get_bool_value("automatic_greeting")
+            self.conversation_summary_enabled = self.__definitions.get_bool_value("conversation_summary_enabled")
             self.max_count_events = self.__definitions.get_int_value("max_count_events")
             self.events_refresh_time = self.__definitions.get_int_value("events_refresh_time")
             self.hourly_time = self.__definitions.get_bool_value("hourly_time")

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -253,6 +253,18 @@ class ConfigLoader:
 LLM parameter list must follow the Python dictionary format: https://www.w3schools.com/python/python_dictionaries.asp""")
                 self.llm_params = None
 
+            # Summary LLM Configuration
+            self.summary_llm_api = self.__definitions.get_string_value("summary_llm_api")
+            self.summary_llm = self.__definitions.get_string_value("summary_model")
+            self.summary_llm = self.summary_llm.split(' |')[0] if ' |' in self.summary_llm else self.summary_llm
+            self.summary_custom_token_count = self.__definitions.get_int_value("summary_custom_token_count")
+            try:
+                self.summary_llm_params: dict[str, Any] | None = json.loads(self.__definitions.get_string_value("summary_llm_params").replace('\n', ''))
+            except Exception as e:
+                logging.error(f"""Error in parsing Summary LLM parameter list: {e}
+Summary LLM parameter list must follow the Python dictionary format: https://www.w3schools.com/python/python_dictionaries.asp""")
+                self.summary_llm_params = None
+
             # self.stop_llm_generation_on_assist_keyword: bool = self.__definitions.get_bool_value("stop_llm_generation_on_assist_keyword")
 
             self.narration_handling: NarrationHandlingEnum = self.__definitions.get_enum_value("narration_handling", NarrationHandlingEnum)

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -253,6 +253,8 @@ class ConfigLoader:
 LLM parameter list must follow the Python dictionary format: https://www.w3schools.com/python/python_dictionaries.asp""")
                 self.llm_params = None
 
+            self.allow_per_character_llm_overrides = self.__definitions.get_bool_value("allow_per_character_llm_overrides")
+
             # Multi-NPC LLM Configuration
             self.multi_npc_llm_api = self.__definitions.get_string_value("multi_npc_llm_api")
             self.multi_npc_llm = self.__definitions.get_string_value("multi_npc_model")

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -253,6 +253,18 @@ class ConfigLoader:
 LLM parameter list must follow the Python dictionary format: https://www.w3schools.com/python/python_dictionaries.asp""")
                 self.llm_params = None
 
+            # Multi-NPC LLM Configuration
+            self.multi_npc_llm_api = self.__definitions.get_string_value("multi_npc_llm_api")
+            self.multi_npc_llm = self.__definitions.get_string_value("multi_npc_model")
+            self.multi_npc_llm = self.multi_npc_llm.split(' |')[0] if ' |' in self.multi_npc_llm else self.multi_npc_llm
+            self.multi_npc_custom_token_count = self.__definitions.get_int_value("multi_npc_custom_token_count")
+            try:
+                self.multi_npc_llm_params: dict[str, Any] | None = json.loads(self.__definitions.get_string_value("multi_npc_llm_params").replace('\n', ''))
+            except Exception as e:
+                logging.error(f"""Error in parsing Multi-NPC LLM parameter list: {e}
+Multi-NPC LLM parameter list must follow the Python dictionary format: https://www.w3schools.com/python/python_dictionaries.asp""")
+                self.multi_npc_llm_params = None
+
             # Summary LLM Configuration
             self.summary_llm_api = self.__definitions.get_string_value("summary_llm_api")
             self.summary_llm = self.__definitions.get_string_value("summary_model")

--- a/src/config/definitions/llm_definitions.py
+++ b/src/config/definitions/llm_definitions.py
@@ -6,6 +6,7 @@ from src.config.types.config_value_int import ConfigValueInt
 from src.config.types.config_value_selection import ConfigValueSelection
 from src.config.types.config_value_string import ConfigValueString
 from src.config.types.config_value_bool import ConfigValueBool
+import json
 
 class NarrationHandlingEnum(Enum):
     CUT_NARRATIONS = auto()
@@ -181,14 +182,44 @@ class LLMDefinitions:
     
     @staticmethod
     def get_summary_llm_params_config_value() -> ConfigValue:
-        value = """{
-                        "max_tokens": 250,
-                        "temperature": 0.7,
-                        "stop": ["#"]
-                    }"""
-        description = """Parameters passed as part of the request to the summary LLM.
-                        A list of the most common parameters can be found here: https://openrouter.ai/docs/parameters.
-                        Note that available parameters can vary per LLM provider.
-                        Lower temperature values are often better for summaries to ensure consistency."""
-        return ConfigValueString("summary_llm_params", "Summary Parameters", description, value, tags=[ConfigValueTag.advanced])
+        description = """Parameters for the summary LLM model. These should be in JSON format.
+                    Common parameters include temperature (0.0-2.0), top_p (0.0-1.0), frequency_penalty (0.0-1.0), presence_penalty (0.0-1.0).
+                    Lower temperature values produce more consistent outputs, while higher values increase creativity."""
+        default_params = json.dumps({"temperature": 0.1, "top_p": 0.9})
+        return ConfigValueString("summary_llm_params","Summary LLM Parameters",description, default_params, tags=[ConfigValueTag.advanced])
+
+    # Multi-NPC LLM Configuration
+    @staticmethod
+    def get_multi_npc_llm_api_config_value() -> ConfigValue:
+        description = """Selects the LLM service to connect to for multi-NPC conversations (either local or via an API).
+        
+            If you are connecting to a local service (KoboldCpp, textgenwebui etc), please ensure that the service is running and a model is loaded. You can also ignore the dropdown options and instead enter a custom URL to connect to other LLM services that provide an OpenAI compatible endpoint.
+            After selecting a service, select the model using the option below. Press the *Update* button to load a list of models available from the service.
+
+            If you are using an API (OpenAI, OpenRouter, etc) ensure you have the correct secret key set in `GPT_SECRET_KEY.txt` for the respective service you are using."""
+        return ConfigValueSelection("multi_npc_llm_api","Multi-NPC LLM Service",description, "OpenRouter", ["OpenRouter", "OpenAI", "KoboldCpp", "textgenwebui"], allows_free_edit=True, tags=[ConfigValueTag.advanced])
+
+    @staticmethod
+    def get_multi_npc_model_config_value() -> ConfigValue:
+        model_description = """Select the model to use for multi-NPC conversations. Press the *Update* button to load a list of models available from the service selected above.
+                            You can use a different model for multi-NPC conversations than for single-NPC conversations.
+                            The list does not provide all details about the models. For additional information please refer to the corresponding sites:
+                            - OpenRouter: https://openrouter.ai/docs#models
+                            - OpenAI: https://platform.openai.com/docs/models https://openai.com/api/pricing/"""
+        return ConfigValueSelection("multi_npc_model","Multi-NPC Model",model_description,"google/gemma-2-9b-it:free",["Custom Model"], allows_values_not_in_options=True, tags=[ConfigValueTag.advanced])
+    
+    @staticmethod
+    def get_multi_npc_custom_token_count_config_value() -> ConfigValue:
+        description = """If the multi-NPC model chosen is not recognised by Mantella, the token count for the given model will default to this number.
+                    If this is not the correct token count for your chosen model, you can change it here.
+                    Keep in mind that if this number is greater than the actual token count of the model, then Mantella will crash if a given conversation exceeds the model's token limit."""
+        return ConfigValueInt("multi_npc_custom_token_count","Multi-NPC Custom Token Count",description, 4096, 4096, 9999999, tags=[ConfigValueTag.advanced])
+
+    @staticmethod
+    def get_multi_npc_llm_params_config_value() -> ConfigValue:
+        description = """Parameters for the multi-NPC LLM model. These should be in JSON format.
+                    Common parameters include temperature (0.0-2.0), top_p (0.0-1.0), frequency_penalty (0.0-1.0), presence_penalty (0.0-1.0).
+                    Higher temperature values can help with more dynamic multi-character interactions."""
+        default_params = json.dumps({"temperature": 0.8, "top_p": 0.9})
+        return ConfigValueString("multi_npc_llm_params","Multi-NPC LLM Parameters",description, default_params, tags=[ConfigValueTag.advanced])
 

--- a/src/config/definitions/llm_definitions.py
+++ b/src/config/definitions/llm_definitions.py
@@ -150,3 +150,45 @@ class LLMDefinitions:
         options = [e.display_name for e in NarrationIndicatorsEnum]
         return ConfigValueSelection("narration_indicators", "Narration indicators to use", description, NarrationIndicatorsEnum.PARANTHESES.display_name, options, corresponding_enums=list(NarrationIndicatorsEnum), tags=[ConfigValueTag.advanced])
 
+    # Summary LLM Configuration
+    @staticmethod
+    def get_summary_llm_api_config_value() -> ConfigValue:
+        description = """Selects the LLM service to use for generating conversation summaries.
+        
+            If you are connecting to a local service (KoboldCpp, textgenwebui etc), please ensure that the service is running and a model is loaded. You can also ignore the dropdown options and instead enter a custom URL to connect to other LLM services that provide an OpenAI compatible endpoint.
+            After selecting a service, select the model using the option below. Press the *Update* button to load a list of models available from the service.
+
+            If you are using an API (OpenAI, OpenRouter, etc) ensure you have the correct secret key set in `GPT_SECRET_KEY.txt` for the respective service you are using.
+            
+            By default, summaries use the same LLM as conversations. Configure this to use a different (potentially cheaper) model for summaries."""
+        return ConfigValueSelection("summary_llm_api","Summary LLM Service",description, "OpenRouter", ["OpenRouter", "OpenAI", "KoboldCpp", "textgenwebui"], allows_free_edit=True, tags=[ConfigValueTag.advanced])
+
+    @staticmethod
+    def get_summary_model_config_value() -> ConfigValue:
+        model_description = """Select the model to use for generating conversation summaries. Press the *Update* button to load a list of models available from the service selected above.
+                            You can use a different (potentially cheaper) model for summaries than for conversations.
+                            The list does not provide all details about the models. For additional information please refer to the corresponding sites:
+                            - OpenRouter: https://openrouter.ai/docs#models
+                            - OpenAI: https://platform.openai.com/docs/models https://openai.com/api/pricing/"""
+        return ConfigValueSelection("summary_model","Summary Model",model_description,"google/gemma-2-9b-it:free",["Custom Model"], allows_values_not_in_options=True, tags=[ConfigValueTag.advanced])
+    
+    @staticmethod
+    def get_summary_custom_token_count_config_value() -> ConfigValue:
+        description = """If the summary model chosen is not recognised by Mantella, the token count for the given model will default to this number.
+                    If this is not the correct token count for your chosen model, you can change it here.
+                    Keep in mind that if this number is greater than the actual token count of the model, then Mantella will crash if a given conversation exceeds the model's token limit."""
+        return ConfigValueInt("summary_custom_token_count","Summary Custom Token Count",description, 4096, 4096, 9999999, tags=[ConfigValueTag.advanced])
+    
+    @staticmethod
+    def get_summary_llm_params_config_value() -> ConfigValue:
+        value = """{
+                        "max_tokens": 250,
+                        "temperature": 0.7,
+                        "stop": ["#"]
+                    }"""
+        description = """Parameters passed as part of the request to the summary LLM.
+                        A list of the most common parameters can be found here: https://openrouter.ai/docs/parameters.
+                        Note that available parameters can vary per LLM provider.
+                        Lower temperature values are often better for summaries to ensure consistency."""
+        return ConfigValueString("summary_llm_params", "Summary Parameters", description, value, tags=[ConfigValueTag.advanced])
+

--- a/src/config/definitions/llm_definitions.py
+++ b/src/config/definitions/llm_definitions.py
@@ -99,6 +99,13 @@ class LLMDefinitions:
                         Note that available parameters can vary per LLM provider."""
         return ConfigValueString("llm_params", "Parameters", description, value, tags=[ConfigValueTag.advanced])
 
+    @staticmethod
+    def get_allow_per_character_llm_overrides_config_value() -> ConfigValue:
+        description = """Allow per-character LLM model overrides for one-on-one conversations.
+                        When enabled, individual characters can use different LLM models specified in the character CSV files (LLM-OR column for OpenRouter models).
+                        The global LLM settings will still be used as the default for characters without specific overrides."""
+        return ConfigValueBool("allow_per_character_llm_overrides", "Allow Per-Character LLM Overrides", description, False, tags=[ConfigValueTag.advanced])
+
     #LLM output parsing options
 
     @staticmethod

--- a/src/config/definitions/other_definitions.py
+++ b/src/config/definitions/other_definitions.py
@@ -123,3 +123,10 @@ class OtherDefinitions:
                         If enabled: Settings changes (LLM model settings, prompts) will be applied without ending conversations.
                         If disabled: Settings changes will end the current conversation and restart (classic behavior)."""
         return ConfigValueBool("hot_swap_enabled", "Enable Hot-Swap Settings", description, True, tags=[ConfigValueTag.advanced])
+    
+    @staticmethod
+    def get_conversation_summary_enabled_config_value() -> ConfigValue:
+        description = """Whether to generate and save conversation summaries when conversations end.
+                        If enabled: Summaries will be generated and saved to help NPCs remember past conversations.
+                        If disabled: No summaries will be generated, conversations will end without sending summary requests to the LLM."""
+        return ConfigValueBool("conversation_summary_enabled", "Enable Conversation Summaries", description, True)

--- a/src/config/definitions/other_definitions.py
+++ b/src/config/definitions/other_definitions.py
@@ -130,3 +130,10 @@ class OtherDefinitions:
                         If enabled: Summaries will be generated and saved to help NPCs remember past conversations.
                         If disabled: No summaries will be generated, conversations will end without sending summary requests to the LLM."""
         return ConfigValueBool("conversation_summary_enabled", "Enable Conversation Summaries", description, True)
+
+    @staticmethod
+    def get_reload_character_data_config_value() -> ConfigValue:
+        description = """Reload character CSV files and overrides from disk to pick up any changes.
+                        This refreshes character data that is cached in memory.
+                        Note: If there is an active conversation, it will be ended before reloading."""
+        return ConfigValueString("reload_character_data", "Reload Character Data", description, "")

--- a/src/config/definitions/other_definitions.py
+++ b/src/config/definitions/other_definitions.py
@@ -116,3 +116,10 @@ class OtherDefinitions:
         description = """Whether to save audio data to an NPC's voice folder instead of MantellaVoice00.
                         Enable this value if voicelines are not being played in-game."""
         return ConfigValueBool("save_audio_data_to_character_folder", "Save Game Audio to Character Folder", description, False, tags=[ConfigValueTag.advanced])
+    
+    @staticmethod
+    def get_hot_swap_enabled_config_value() -> ConfigValue:
+        description = """Whether to enable hot-swapping settings during active conversations.
+                        If enabled: Settings changes (LLM model settings, prompts) will be applied without ending conversations.
+                        If disabled: Settings changes will end the current conversation and restart (classic behavior)."""
+        return ConfigValueBool("hot_swap_enabled", "Enable Hot-Swap Settings", description, True, tags=[ConfigValueTag.advanced])

--- a/src/config/mantella_config_value_definitions_classic.py
+++ b/src/config/mantella_config_value_definitions_classic.py
@@ -123,6 +123,7 @@ class MantellaConfigValueDefinitionsClassic:
         http_category = ConfigValueGroup("HTTP", "HTTP", "Settings for the HTTP server MantellaSoftware provides for the games to connect to", on_value_change_callback)
         http_category.add_config_value(OtherDefinitions.get_port_config_value())
         http_category.add_config_value(OtherDefinitions.get_show_http_debug_messages_config_value())
+        http_category.add_config_value(OtherDefinitions.get_hot_swap_enabled_config_value())
         result.append(http_category)
         
         # debugging_category = ConfigValueGroup("Debugging", "Debugging", "Settings that might help debug problems with Mantella", on_value_change_callback)

--- a/src/config/mantella_config_value_definitions_classic.py
+++ b/src/config/mantella_config_value_definitions_classic.py
@@ -104,6 +104,12 @@ class MantellaConfigValueDefinitionsClassic:
         llm_advanced_category.add_config_value(LLMDefinitions.get_frequency_penalty_config_value())
         llm_advanced_category.add_config_value(LLMDefinitions.get_max_tokens_config_value())
         
+        # Multi-NPC LLM Configuration
+        llm_advanced_category.add_config_value(LLMDefinitions.get_multi_npc_llm_api_config_value())
+        llm_advanced_category.add_config_value(LLMDefinitions.get_multi_npc_model_config_value())
+        llm_advanced_category.add_config_value(LLMDefinitions.get_multi_npc_custom_token_count_config_value())
+        llm_advanced_category.add_config_value(LLMDefinitions.get_multi_npc_llm_params_config_value())
+        
         # Summary LLM Configuration
         llm_advanced_category.add_config_value(LLMDefinitions.get_summary_llm_api_config_value())
         llm_advanced_category.add_config_value(LLMDefinitions.get_summary_model_config_value())

--- a/src/config/mantella_config_value_definitions_classic.py
+++ b/src/config/mantella_config_value_definitions_classic.py
@@ -103,6 +103,13 @@ class MantellaConfigValueDefinitionsClassic:
         llm_advanced_category.add_config_value(LLMDefinitions.get_stop_config_value())
         llm_advanced_category.add_config_value(LLMDefinitions.get_frequency_penalty_config_value())
         llm_advanced_category.add_config_value(LLMDefinitions.get_max_tokens_config_value())
+        
+        # Summary LLM Configuration
+        llm_advanced_category.add_config_value(LLMDefinitions.get_summary_llm_api_config_value())
+        llm_advanced_category.add_config_value(LLMDefinitions.get_summary_model_config_value())
+        llm_advanced_category.add_config_value(LLMDefinitions.get_summary_custom_token_count_config_value())
+        llm_advanced_category.add_config_value(LLMDefinitions.get_summary_llm_params_config_value())
+        
         result.append(llm_advanced_category)
         
         speech_advanced_category = ConfigValueGroup("Speech.Advanced", "Speech Advanced", "More advanced settings concerning the voice generation", on_value_change_callback)

--- a/src/config/mantella_config_value_definitions_classic.py
+++ b/src/config/mantella_config_value_definitions_classic.py
@@ -55,6 +55,7 @@ class MantellaConfigValueDefinitionsClassic:
         
         conversation_category = ConfigValueGroup("Conversation", "Conversation", "Settings about the flow of a conversation", on_value_change_callback)
         conversation_category.add_config_value(OtherDefinitions.get_automatic_greeting_folder_config_value())
+        conversation_category.add_config_value(OtherDefinitions.get_conversation_summary_enabled_config_value())
         result.append(conversation_category)
         
         cleanup_category = ConfigValueGroup("Cleanup", "Cleanup", "", on_value_change_callback)

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -48,6 +48,13 @@ class MantellaConfigValueDefinitionsNew:
         # llm_category.add_config_value(LLMDefinitions.get_try_filter_narration())
         llm_category.add_config_value(LLMDefinitions.get_llm_params_config_value())
         # llm_category.add_config_value(LLMDefinitions.get_stop_llm_generation_on_assist_keyword())
+        
+        # Summary LLM Configuration
+        llm_category.add_config_value(LLMDefinitions.get_summary_llm_api_config_value())
+        llm_category.add_config_value(LLMDefinitions.get_summary_model_config_value())
+        llm_category.add_config_value(LLMDefinitions.get_summary_custom_token_count_config_value())
+        llm_category.add_config_value(LLMDefinitions.get_summary_llm_params_config_value())
+        
         llm_category.add_config_value(LLMDefinitions.get_narration_handling())
         llm_category.add_config_value(LLMDefinitions.get_narrator_voice())
         llm_category.add_config_value(LLMDefinitions.get_narration_start_indicators())

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -156,6 +156,7 @@ class MantellaConfigValueDefinitionsNew:
         other_category.add_config_value(OtherDefinitions.get_voice_player_input())
         other_category.add_config_value(OtherDefinitions.get_player_voice_model())
         other_category.add_config_value(OtherDefinitions.get_save_audio_data_to_character_folder_config_value())
+        other_category.add_config_value(OtherDefinitions.get_hot_swap_enabled_config_value())
         other_category.add_config_value(OtherDefinitions.get_port_config_value())
         other_category.add_config_value(OtherDefinitions.get_show_http_debug_messages_config_value())
         other_category.add_config_value(OtherDefinitions.get_advanced_logs_config_value())

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -163,6 +163,7 @@ class MantellaConfigValueDefinitionsNew:
         other_category.add_config_value(OtherDefinitions.get_automatic_greeting_config_value())
         other_category.add_config_value(OtherDefinitions.get_conversation_summary_enabled_config_value())
         other_category.add_config_value(OtherDefinitions.get_active_actions(actions))
+        other_category.add_config_value(OtherDefinitions.get_reload_character_data_config_value())
         other_category.add_config_value(OtherDefinitions.get_max_count_events_config_value())
         other_category.add_config_value(OtherDefinitions.get_events_refresh_time_config_value())
         other_category.add_config_value(OtherDefinitions.get_hourly_time_config_value())

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -148,6 +148,7 @@ class MantellaConfigValueDefinitionsNew:
 
         other_category = ConfigValueGroup("Other", "Other", "Other settings.", on_value_change_callback)
         other_category.add_config_value(OtherDefinitions.get_automatic_greeting_config_value())
+        other_category.add_config_value(OtherDefinitions.get_conversation_summary_enabled_config_value())
         other_category.add_config_value(OtherDefinitions.get_active_actions(actions))
         other_category.add_config_value(OtherDefinitions.get_max_count_events_config_value())
         other_category.add_config_value(OtherDefinitions.get_events_refresh_time_config_value())

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -47,6 +47,7 @@ class MantellaConfigValueDefinitionsNew:
         llm_category.add_config_value(LLMDefinitions.get_wait_time_buffer_config_value())
         # llm_category.add_config_value(LLMDefinitions.get_try_filter_narration())
         llm_category.add_config_value(LLMDefinitions.get_llm_params_config_value())
+        llm_category.add_config_value(LLMDefinitions.get_allow_per_character_llm_overrides_config_value())
         # llm_category.add_config_value(LLMDefinitions.get_stop_llm_generation_on_assist_keyword())
         
         # Multi-NPC LLM Configuration

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -49,6 +49,12 @@ class MantellaConfigValueDefinitionsNew:
         llm_category.add_config_value(LLMDefinitions.get_llm_params_config_value())
         # llm_category.add_config_value(LLMDefinitions.get_stop_llm_generation_on_assist_keyword())
         
+        # Multi-NPC LLM Configuration
+        llm_category.add_config_value(LLMDefinitions.get_multi_npc_llm_api_config_value())
+        llm_category.add_config_value(LLMDefinitions.get_multi_npc_model_config_value())
+        llm_category.add_config_value(LLMDefinitions.get_multi_npc_custom_token_count_config_value())
+        llm_category.add_config_value(LLMDefinitions.get_multi_npc_llm_params_config_value())
+        
         # Summary LLM Configuration
         llm_category.add_config_value(LLMDefinitions.get_summary_llm_api_config_value())
         llm_category.add_config_value(LLMDefinitions.get_summary_model_config_value())

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -53,6 +53,45 @@ class Context:
     def config(self) -> ConfigLoader:
         return self.__config
 
+    @utils.time_it
+    def hot_swap_settings(self, config: ConfigLoader, client: LLMClient, rememberer: Remembering) -> bool:
+        """Attempts to hot-swap settings without ending the conversation.
+        
+        Args:
+            config: Updated config loader instance
+            client: Updated LLM client instance
+            rememberer: Updated rememberer instance
+            
+        Returns:
+            bool: True if hot-swap was successful, False otherwise
+        """
+        try:
+            # Update basic components
+            self.__config = config
+            self.__client = client
+            self.__rememberer = rememberer
+            
+            # Update config-derived values
+            self.__hourly_time = config.hourly_time
+            self.__game = config.game
+            
+            # Update game-specific location if game changed
+            if self.__game.base_game == GameEnum.FALLOUT4:
+                default_location = 'the Commonwealth'
+            else:
+                default_location = "Skyrim"
+                
+            # Only update location if it's currently the default
+            if self.__location in ['the Commonwealth', 'Skyrim']:
+                self.__location = default_location
+            
+            logging.info("Context hot-swap completed successfully")
+            return True
+            
+        except Exception as e:
+            logging.error(f"Context hot-swap failed: {e}")
+            return False
+
     @property
     def prompt_multinpc(self) -> str:
         return self.__config.multi_npc_prompt

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -212,7 +212,7 @@ class Context:
                 self.__prev_location = self.__location
                 self.__ingame_events.append(f"The location is now {location}.")
         
-        if in_game_time:
+        if in_game_time is not None:
             self.__ingame_time = in_game_time
             in_game_time_twelve_hour = in_game_time - 12 if in_game_time > 12 else in_game_time
             if self.__hourly_time:

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -458,7 +458,10 @@ class Conversation:
             if not npc.is_player_character:
                 characters_object.add_or_update_character(npc)
                 conversation_log.save_conversation_log(npc, self.__messages.transform_to_openai_messages(self.__messages.get_talk_only()), self.__context.world_id)
-        self.__rememberer.save_conversation_state(self.__messages, characters_object, self.__context.world_id, is_reload)
+        
+        # Only save conversation state (which triggers summary generation) if summaries are enabled
+        if self.__context.config.conversation_summary_enabled:
+            self.__rememberer.save_conversation_state(self.__messages, characters_object, self.__context.world_id, is_reload)
 
     @utils.time_it
     def __initiate_reload_conversation(self):

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -85,6 +85,11 @@ class GameStateManager:
         self.__conv_has_narrator: bool = config.narration_handling == NarrationHandlingEnum.USE_NARRATOR
         self.__should_reload: bool = False
 
+    @property
+    def game(self) -> Gameable:
+        """Get the current game instance"""
+        return self.__game
+
     @utils.time_it
     def hot_swap_settings(self, game: Gameable, chat_manager: ChatManager, config: ConfigLoader, llm_client: LLMClient, secret_key_file: str, image_secret_key_file: str) -> bool:
         """Attempts to hot-swap settings without ending active conversations.

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -411,6 +411,7 @@ class GameStateManager:
             csv_in_game_voice_model: str = ""
             advanced_voice_model: str = ""
             voice_accent: str = ""
+            llm_openrouter_model: str = ""
             is_player_character: bool = bool(json[comm_consts.KEY_ACTOR_ISPLAYER])
             if self.__talk and self.__talk.contains_character(ref_id):
                 already_loaded_character: Character | None = self.__talk.get_character(ref_id)
@@ -420,6 +421,7 @@ class GameStateManager:
                     csv_in_game_voice_model = already_loaded_character.csv_in_game_voice_model
                     advanced_voice_model = already_loaded_character.advanced_voice_model
                     voice_accent = already_loaded_character.voice_accent
+                    llm_openrouter_model = already_loaded_character.llm_openrouter_model
                     is_generic_npc = already_loaded_character.is_generic_npc
             elif self.__talk and not is_player_character :#If this is not the player and the character has not already been loaded
                 external_info: external_character_info = self.__game.load_external_character_info(base_id, character_name, race, gender, actor_voice_model)
@@ -429,6 +431,7 @@ class GameStateManager:
                 csv_in_game_voice_model = external_info.csv_in_game_voice_model
                 advanced_voice_model = external_info.advanced_voice_model
                 voice_accent = external_info.voice_accent
+                llm_openrouter_model = external_info.llm_openrouter_model
                 is_generic_npc = external_info.is_generic_npc
                 if is_generic_npc:
                     character_name = external_info.name
@@ -456,7 +459,8 @@ class GameStateManager:
                             advanced_voice_model,
                             voice_accent,
                             equipment,
-                            custom_values)
+                            custom_values,
+                            llm_openrouter_model)
         except CharacterDoesNotExist:                 
             logging.log(23, 'Restarting...')
             return None 

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -53,6 +53,26 @@ class GameStateManager:
             # Use the same client for summaries
             summary_client = None
             
+        # Create separate LLM client for multi-NPC conversations if different settings are configured
+        if (config.multi_npc_llm_api != config.llm_api or 
+            config.multi_npc_llm != config.llm or 
+            config.multi_npc_llm_params != config.llm_params or 
+            config.multi_npc_custom_token_count != config.custom_token_count):
+            # Create separate client for multi-NPC conversations with different settings
+            multi_npc_client = ClientBase(
+                config.multi_npc_llm_api,
+                config.multi_npc_llm,
+                config.multi_npc_llm_params,
+                config.multi_npc_custom_token_count,
+                [api_file]
+            )
+        else:
+            # Use the same client for multi-NPC conversations
+            multi_npc_client = None
+        
+        # Update chat manager with multi-NPC client
+        chat_manager.update_multi_npc_client(multi_npc_client)
+            
         self.__rememberer: Remembering = Summaries(game, config, client, language_info['language'], summary_client)
         self.__talk: Conversation | None = None
         self.__mic_input: bool = False
@@ -114,8 +134,28 @@ class GameStateManager:
                 # Use the same client for summaries
                 summary_client = None
             
+            # Create separate LLM client for multi-NPC conversations if different settings are configured
+            if (config.multi_npc_llm_api != config.llm_api or 
+                config.multi_npc_llm != config.llm or 
+                config.multi_npc_llm_params != config.llm_params or 
+                config.multi_npc_custom_token_count != config.custom_token_count):
+                # Create separate client for multi-NPC conversations with different settings
+                multi_npc_client = ClientBase(
+                    config.multi_npc_llm_api,
+                    config.multi_npc_llm,
+                    config.multi_npc_llm_params,
+                    config.multi_npc_custom_token_count,
+                    [secret_key_file]
+                )
+            else:
+                # Use the same client for multi-NPC conversations
+                multi_npc_client = None
+            
             # Update rememberer with new config and summary client
             self.__rememberer = Summaries(game, config, self.__client, self.__language_info['language'], summary_client)
+            
+            # Update chat manager with multi-NPC client
+            chat_manager.update_multi_npc_client(multi_npc_client)
             
             # If there's an active conversation, update it with new settings
             if self.__talk:

--- a/src/games/external_character_info.py
+++ b/src/games/external_character_info.py
@@ -1,7 +1,7 @@
 class external_character_info:
     """_summary_
     """
-    def __init__(self, name: str, is_generic_npc: bool, bio: str, ingame_voice_model: str, tts_voice_model: str, csv_in_game_voice_model: str, advanced_voice_model: str, voice_accent: str) -> None:
+    def __init__(self, name: str, is_generic_npc: bool, bio: str, ingame_voice_model: str, tts_voice_model: str, csv_in_game_voice_model: str, advanced_voice_model: str, voice_accent: str, llm_openrouter_model: str = "") -> None:
         self.__name: str = name
         self.__is_generic_npc: bool = is_generic_npc
         self.__bio: str = bio
@@ -10,6 +10,7 @@ class external_character_info:
         self.__csv_in_game_voice_model: str = csv_in_game_voice_model
         self.__advanced_voice_model: str = advanced_voice_model
         self.__voice_accent: str = voice_accent
+        self.__llm_openrouter_model: str = llm_openrouter_model
     
     @property
     def name(self) -> str:
@@ -42,3 +43,7 @@ class external_character_info:
     @property
     def voice_accent(self) -> str:
         return self.__voice_accent
+    
+    @property
+    def llm_openrouter_model(self) -> str:
+        return self.__llm_openrouter_model

--- a/src/games/gameable.py
+++ b/src/games/gameable.py
@@ -360,3 +360,29 @@ class Gameable(ABC):
         with wave.open(os.path.join(voice_folder_path, f"{filename}.wav"), 'wb') as muted_wav:
             muted_wav.setparams(params)
             muted_wav.writeframes(muted_frames)
+
+    @utils.time_it
+    def hot_swap_settings(self, config: ConfigLoader) -> bool:
+        """Attempts to hot-swap settings without reloading character data.
+        
+        Args:
+            config: Updated config loader instance
+            
+        Returns:
+            bool: True if hot-swap was successful, False otherwise
+        """
+        try:
+            # Update VR setting
+            self._is_vr = config.game.is_vr
+            
+            # Update conversation folder path
+            mantella_game_folder_path = self.game_name_in_filepath.capitalize()
+            self.__conversation_folder_path = config.save_folder + f"data/{mantella_game_folder_path}/conversations"
+            conversation_log.game_path = self.__conversation_folder_path
+            
+            logging.info(f"{self.__class__.__name__} hot-swap completed successfully")
+            return True
+            
+        except Exception as e:
+            logging.error(f"{self.__class__.__name__} hot-swap failed: {e}")
+            return False

--- a/src/games/skyrim.py
+++ b/src/games/skyrim.py
@@ -200,6 +200,32 @@ class Skyrim(Gameable):
         logging.log(23, f"{speaker.name} should speak")
 
     @utils.time_it
+    def hot_swap_settings(self, config: ConfigLoader) -> bool:
+        """Attempts to hot-swap settings without reloading character data.
+        
+        Args:
+            config: Updated config loader instance
+            
+        Returns:
+            bool: True if hot-swap was successful, False otherwise
+        """
+        try:
+            # Update base game settings first
+            if not super().hot_swap_settings(config):
+                return False
+            
+            # Update Skyrim specific settings
+            self.__tts_service = config.tts_service
+            # Note: __image_analysis_filepath is empty for Skyrim, no update needed
+            
+            logging.info("Skyrim hot-swap completed successfully")
+            return True
+            
+        except Exception as e:
+            logging.error(f"Skyrim hot-swap failed: {e}")
+            return False
+
+    @utils.time_it
     def is_sentence_allowed(self, text: str, count_sentence_in_text: int) -> bool:
         if ('assist' in text) and (count_sentence_in_text > 0):
             logging.log(23, f"'assist' keyword found. Ignoring sentence: {text.strip()}")

--- a/src/games/skyrim.py
+++ b/src/games/skyrim.py
@@ -64,7 +64,7 @@ class Skyrim(Gameable):
         character_info, is_generic_npc = self.find_character_info(base_id, name, race, gender, ingame_voice_model)
         actor_voice_model_name = ingame_voice_model.split('<')[1].split(' ')[0]
 
-        return external_character_info(name, is_generic_npc, character_info["bio"], actor_voice_model_name, character_info['voice_model'], character_info['skyrim_voice_folder'], character_info['advanced_voice_model'], character_info.get('voice_accent', None))
+        return external_character_info(name, is_generic_npc, character_info["bio"], actor_voice_model_name, character_info['voice_model'], character_info['skyrim_voice_folder'], character_info['advanced_voice_model'], character_info.get('voice_accent', None), character_info.get('LLM-OR', ''))
     
     @utils.time_it
     def find_best_voice_model(self, actor_race: str | None, actor_sex: int | None, ingame_voice_model: str, library_search:bool = True) -> str:

--- a/src/http/routes/mantella_route.py
+++ b/src/http/routes/mantella_route.py
@@ -66,6 +66,7 @@ class mantella_route(routeable):
                 tts = Piper(self._config, game)
 
             llm_client = LLMClient(self._config, self.__secret_key_file, self.__image_secret_key_file)
+            
             chat_manager = ChatManager(self._config, tts, llm_client)
             
             # Try to hot-swap the GameStateManager components

--- a/src/http/routes/mantella_route.py
+++ b/src/http/routes/mantella_route.py
@@ -114,6 +114,17 @@ class mantella_route(routeable):
         chat_manager = ChatManager(self._config, tts, llm_client)
         self.__game = GameStateManager(game, chat_manager, self._config, self.__language_info, llm_client, self.__stt_secret_key_file, self.__secret_key_file)
 
+        # Set the global reference for UI access
+        try:
+            from src.ui.settings_ui_constructor import set_game_manager_reference
+            logging.info("Setting global game manager reference for character data reload...")
+            set_game_manager_reference(self.__game)
+            logging.info("Global game manager reference has been set for character data reload.")
+        except ImportError:
+            # If the UI module is not available, just continue
+            logging.warning("Could not import set_game_manager_reference. Character data reload button in UI will not work.")
+            pass
+
     @utils.time_it
     def add_route_to_server(self, app: FastAPI):
         @app.post("/mantella")

--- a/src/llm/llm_client.py
+++ b/src/llm/llm_client.py
@@ -22,3 +22,49 @@ class LLMClient(ClientBase):
         if config.vision_enabled:
             logging.info(f"Setting up vision language model...")
             self._image_client: ImageClient | None = ImageClient(config, secret_key_file, image_secret_key_file)
+    
+    @utils.time_it
+    def hot_swap_settings(self, config: ConfigLoader, secret_key_file: str, image_secret_key_file: str) -> bool:
+        """Attempts to hot-swap settings without ending the conversation.
+        
+        Args:
+            config: Updated config loader instance
+            secret_key_file: Updated secret key file
+            image_secret_key_file: Updated image secret key file
+            
+        Returns:
+            bool: True if hot-swap was successful, False otherwise
+        """
+        try:
+            # Update base client settings
+            success = super().hot_swap_settings(
+                config.llm_api, 
+                config.llm, 
+                config.llm_params, 
+                config.custom_token_count, 
+                [secret_key_file]
+            )
+            
+            if not success:
+                return False
+            
+            # Update image client if vision is enabled
+            if config.vision_enabled:
+                if self._image_client:
+                    # Update existing image client
+                    if hasattr(self._image_client, 'hot_swap_settings'):
+                        self._image_client.hot_swap_settings(config, secret_key_file, image_secret_key_file)
+                else:
+                    # Create new image client
+                    logging.info(f"Setting up vision language model...")
+                    self._image_client = ImageClient(config, secret_key_file, image_secret_key_file)
+            else:
+                # Disable image client if vision is disabled
+                self._image_client = None
+            
+            logging.info("LLMClient hot-swap completed successfully")
+            return True
+            
+        except Exception as e:
+            logging.error(f"LLMClient hot-swap failed: {e}")
+            return False

--- a/src/llm/message_thread.py
+++ b/src/llm/message_thread.py
@@ -4,6 +4,7 @@ from src.llm.messages import Message, SystemMessage, UserMessage, AssistantMessa
 from typing import Callable
 from openai.types.chat import ChatCompletionMessageParam
 from src import utils
+import logging
 
 class message_thread():
     """A thread of messages consisting of system-, user- and assistant-messages.
@@ -181,3 +182,29 @@ class message_thread():
             self.replace_message_type(message_instance,message_type)
         else:
             self.add_message(message_instance)
+    
+    @utils.time_it
+    def hot_swap_settings(self, config: ConfigLoader) -> bool:
+        """Attempts to hot-swap settings without ending the conversation.
+        
+        Args:
+            config: Updated config loader instance
+            
+        Returns:
+            bool: True if hot-swap was successful, False otherwise
+        """
+        try:
+            # Update config reference
+            self.__config = config
+            
+            # Update all messages with new config for narration indicators
+            for message in self.__messages:
+                if hasattr(message, 'hot_swap_settings'):
+                    message.hot_swap_settings(config)
+            
+            logging.info("message_thread hot-swap completed successfully")
+            return True
+            
+        except Exception as e:
+            logging.error(f"message_thread hot-swap failed: {e}")
+            return False

--- a/src/llm/messages.py
+++ b/src/llm/messages.py
@@ -7,6 +7,7 @@ from src.character_manager import Character
 
 from src.llm.sentence import Sentence
 from src import utils
+import logging
 
 class Message(ABC):
     """Base class for messages 
@@ -73,6 +74,34 @@ class Message(ABC):
     @abstractmethod
     def get_dict_formatted_string(self) -> str:
         pass
+    
+    @utils.time_it
+    def hot_swap_settings(self, config: ConfigLoader) -> bool:
+        """Attempts to hot-swap settings without ending the conversation.
+        
+        Args:
+            config: Updated config loader instance
+            
+        Returns:
+            bool: True if hot-swap was successful, False otherwise
+        """
+        try:
+            # Update narration indicators
+            if config.narration_indicators == NarrationIndicatorsEnum.BRACKETS:
+                self.__narration_start = "["
+                self.__narration_end = "]"
+            elif config.narration_indicators == NarrationIndicatorsEnum.ASTERISKS:
+                self.__narration_start = "*"
+                self.__narration_end = "*"
+            else:
+                self.__narration_start = "("
+                self.__narration_end = ")"
+            
+            return True
+            
+        except Exception as e:
+            logging.error(f"Message hot-swap failed: {e}")
+            return False
 
 class SystemMessage(Message):
     """A message with the role 'system'. Usually used as the initial main prompt of an exchange with the LLM

--- a/src/llm/output/sentence_accumulator.py
+++ b/src/llm/output/sentence_accumulator.py
@@ -9,8 +9,12 @@ class sentence_accumulator:
     def __init__(self, cut_indicators: list[str]) -> None:
         self.__cut_indicators = cut_indicators
         self.__cleaned_llm_output: str = ""
-        base_regex_def = "^.*?[{sentence_end_chars}]+"
-        self.__sentence_end_reg = re.compile(base_regex_def.format(sentence_end_chars = "\\" + "\\".join(cut_indicators)))
+        # Updated regex: only match a period if it is not part of an ellipsis (three or more periods)
+        period = '\.'
+        other_chars = [c for c in cut_indicators if c != '.']
+        other_chars_escaped = ''.join([re.escape(c) for c in other_chars])
+        base_regex_def = rf"^.*?(?:(?<!\.)\.(?!\.)|[{other_chars_escaped}])+"
+        self.__sentence_end_reg = re.compile(base_regex_def)
         self.__unparseable: str = ""
         self.__prepared_match: str = ""
         self.__cleaner = clean_sentence_parser()

--- a/src/llm/output/sentence_end_parser.py
+++ b/src/llm/output/sentence_end_parser.py
@@ -9,8 +9,19 @@ class sentence_end_parser(output_parser):
     def __init__(self, end_of_sentence_chars: list[str] = ['.', '?', '!', ';', '。', '？', '！', '；', '：']) -> None:
         super().__init__()
         self.__end_of_sentence_chars = [unicodedata.normalize('NFKC', char) for char in end_of_sentence_chars]
-        base_regex_def = "^.*?[{sentence_end_chars}]+"
-        self.__sentence_end_reg = re.compile(base_regex_def.format(sentence_end_chars = "\\" + "\\".join(self.__end_of_sentence_chars)))
+        # Updated regex: only match a period if it is not part of an ellipsis (three or more periods)
+        # For other sentence end chars, match as before
+        # This regex will match a single period not followed or preceded by another period, or any of the other end chars
+        # Note: '：' (fullwidth colon) should be removed if you don't want it as a terminator
+        period = '\.'
+        # Remove colon if not wanted
+        other_chars = [c for c in self.__end_of_sentence_chars if c != '.']
+        # Build regex: match a period not part of ellipsis, or any other end char
+        # (?!\.{2,}) ensures not followed by two or more periods (i.e., not the start of an ellipsis)
+        # (?<!\.) ensures not preceded by a period (i.e., not the middle or end of an ellipsis)
+        other_chars_escaped = ''.join([re.escape(c) for c in other_chars])
+        base_regex_def = rf"^.*?(?:(?<!\.)\.(?!\.)|[{other_chars_escaped}])+"
+        self.__sentence_end_reg = re.compile(base_regex_def)
 
     def cut_sentence(self, output: str, current_settings: sentence_generation_settings) -> tuple[SentenceContent | None, str]:
         match = self.__sentence_end_reg.match(output)

--- a/src/output_manager.py
+++ b/src/output_manager.py
@@ -44,6 +44,34 @@ class ChatManager:
         return self.__tts
     
     @utils.time_it
+    def hot_swap_settings(self, config: ConfigLoader, tts: TTSable, client: AIClient) -> bool:
+        """Attempts to hot-swap settings without ending the conversation.
+        
+        Args:
+            config: Updated config loader instance
+            tts: Updated TTS instance
+            client: Updated AI client instance
+            
+        Returns:
+            bool: True if hot-swap was successful, False otherwise
+        """
+        try:
+            # Update basic components
+            self.__config = config
+            self.__tts = tts
+            self.__client = client
+            
+            # Reset first sentence flag for new TTS instance
+            self.__is_first_sentence = False
+            
+            logging.info("ChatManager hot-swap completed successfully")
+            return True
+            
+        except Exception as e:
+            logging.error(f"ChatManager hot-swap failed: {e}")
+            return False
+    
+    @utils.time_it
     def generate_sentence(self, content: SentenceContent) -> Sentence:
         """Generates the audio for a text and returns the corresponding sentence
 

--- a/src/ui/settings_ui_constructor.py
+++ b/src/ui/settings_ui_constructor.py
@@ -30,7 +30,7 @@ class SettingConfig(NamedTuple):
 
 class ModelConfig(TypedDict):
     dependent_config: str  # The config value this model depends on (e.g., "llm_api")
-    model_list_getter: Callable[[str], Any]  # Function to get model list based on service
+    model_list_getter: Callable[[str, str, str, bool], Any]  # Function to get model list based on service, secret_key_file, default_model, is_vision
 
 class SettingsUIConstructor(ConfigValueVisitor):
     def __init__(self) -> None:
@@ -295,6 +295,10 @@ class SettingsUIConstructor(ConfigValueVisitor):
             },
             "vision_model": {
                 "dependent_config": "vision_llm_api",
+                "model_list_getter": ClientBase.get_model_list,
+            },
+            "summary_model": {
+                "dependent_config": "summary_llm_api",
                 "model_list_getter": ClientBase.get_model_list,
             }
         }

--- a/src/ui/settings_ui_constructor.py
+++ b/src/ui/settings_ui_constructor.py
@@ -297,6 +297,10 @@ class SettingsUIConstructor(ConfigValueVisitor):
                 "dependent_config": "vision_llm_api",
                 "model_list_getter": ClientBase.get_model_list,
             },
+            "multi_npc_model": {
+                "dependent_config": "multi_npc_llm_api",
+                "model_list_getter": ClientBase.get_model_list,
+            },
             "summary_model": {
                 "dependent_config": "summary_llm_api",
                 "model_list_getter": ClientBase.get_model_list,


### PR DESCRIPTION
- Add support for LLM selection for one-on-one conversation for each character. Now that we have an entry for each character in the csv file, we can add a new column (LLM-OR) to support this. At this iteration, only support Openrouter models. (But need to leave the door open, write codes in a way to be able to extend to other API services like Nanogpt etc. if we support Nanogpt in the future, there will be a new column for Nanogpt in the csv file called LLM-Nano or something like that). We consider the current llm selection for one-on-one conversation as the global setting. Need to add a button in the Large Language Model tab, to toggle whether to allow the LLM options in the file to overwrite the global setting for each individual.

- Add logs at the beginning of each response to document which LLM it is from