### PR TITLE
add optional opentelemetry tracing

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,12 +8,13 @@ from src.ui.start_ui import StartUI
 
 def main():
     try:
+        mantella_version = '0.13.1'
         config, language_info = MantellaSetup().initialise(
             config_file='config.ini',
             logging_file='logging.log', 
-            language_file='data/language_support.csv')
+            language_file='data/language_support.csv',
+            mantella_version=mantella_version)
 
-        mantella_version = '0.13.1'
         logging.log(24, f'\nMantella v{mantella_version}')
 
         mantella_http_server = http_server()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,8 @@ opencv-python==4.10.0.84
 sounddevice==0.5.1
 silero_vad==5.1.2
 git+https://github.com/usefulsensors/moonshine.git@2f6282347950c8d711bd7319287babb87ec5a92d#subdirectory=moonshine-onnx
+opentelemetry-api==1.27.0
+opentelemetry-sdk==1.27.0
+opentelemetry-exporter-otlp-proto-grpc==1.27.0
+opentelemetry-instrumentation-requests==0.48b0
+opentelemetry-instrumentation-logging==0.48b0

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -324,7 +324,12 @@ LLM parameter list must follow the Python dictionary format: https://www.w3schoo
                 logging.error(f"""Error in parsing LLM parameter list: {e}
 LLM parameter list must follow the Python dictionary format: https://www.w3schools.com/python/python_dictionaries.asp""")
                 self.vision_llm_params = None
-            
+
+            # Telemetry
+            self.enable_telemetry = self.__definitions.get_bool_value("enable_telemetry")
+            self.telemetry_otlp_endpoint = self.__definitions.get_string_value("telemetry_otlp_endpoint")
+            self.telemetry_protocol = self.__definitions.get_string_value("telemetry_protocol")
+
             pass
         except Exception as e:
             utils.play_error_sound()

--- a/src/config/definitions/telemetry_definitions.py
+++ b/src/config/definitions/telemetry_definitions.py
@@ -1,0 +1,18 @@
+from src.config.types.config_value import ConfigValue
+from src.config.types.config_value_bool import ConfigValueBool
+from src.config.types.config_value_string import ConfigValueString
+
+
+class TelemetryDefinitions:
+    #Base
+    @staticmethod
+    def get_enable_telemetry_config_value() -> ConfigValue:
+        return ConfigValueBool("enable_telemetry","","Enable open telemetry for tracing",False)
+
+    @staticmethod
+    def get_telemetry_otlp_endpoint_config_value() -> ConfigValue:
+        return ConfigValueString("telemetry_otlp_endpoint","","Open Telemetry endpoint","")
+    
+    @staticmethod
+    def get_telemetry_protocol_config_value() -> ConfigValue:
+        return ConfigValueString("telemetry_protocol","","Open Telemetry protocol (can be 'http/protobuf' or 'grpc')","http/protobuf")

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -13,6 +13,7 @@ from src.config.definitions.prompt_definitions import PromptDefinitions
 from src.config.definitions.stt_definitions import STTDefinitions
 from src.config.definitions.tts_definitions import TTSDefinitions
 from src.config.definitions.vision_definitions import VisionDefinitions
+from src.config.definitions.telemetry_definitions import TelemetryDefinitions
 import sys
 
 
@@ -166,5 +167,11 @@ class MantellaConfigValueDefinitionsNew:
         # other_category.add_config_value(OtherDefinitions.get_default_player_response_config_value())
         # other_category.add_config_value(OtherDefinitions.get_exit_on_first_exchange_config_value())
         result.add_base_group(other_category)
-      
+
+        telemetry_category = ConfigValueGroup("Telemetry", "Telemetry", "Telemetry settings.", on_value_change_callback)
+        telemetry_category.add_config_value(TelemetryDefinitions.get_enable_telemetry_config_value())
+        telemetry_category.add_config_value(TelemetryDefinitions.get_telemetry_otlp_endpoint_config_value())
+        telemetry_category.add_config_value(TelemetryDefinitions.get_telemetry_protocol_config_value())
+        result.add_base_group(telemetry_category)
+
         return result

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -5,6 +5,7 @@ import time
 from typing import Any
 from src.llm.ai_client import AIClient
 from src.llm.sentence_content import SentenceTypeEnum, SentenceContent
+from opentelemetry import context as otel_context
 from src.characters_manager import Characters
 from src.conversation.conversation_log import conversation_log
 from src.conversation.action import Action
@@ -369,7 +370,8 @@ class Conversation:
         with self.__generation_start_lock:
             if not self.__generation_thread:
                 self.__sentences.is_more_to_come = True
-                self.__generation_thread = Thread(None, self.__output_manager.generate_response, None, [self.__messages, self.__context.npcs_in_conversation, self.__sentences, self.context.config.actions]).start()   
+                current_context = otel_context.get_current() 
+                self.__generation_thread = Thread(None, self.__output_manager.generate_response, None, [self.__messages, self.__context.npcs_in_conversation, self.__sentences, self.context.config.actions, current_context]).start()   
 
     @utils.time_it
     def __stop_generation(self):

--- a/src/llm/ai_client.py
+++ b/src/llm/ai_client.py
@@ -4,7 +4,7 @@ from typing import AsyncGenerator
 from src.llm.message_thread import message_thread
 from src.llm.messages import Message
 from src.llm.llm_model_list import LLMModelList
-
+from opentelemetry.context.context import Context
 
 class AIClient(ABC):
 
@@ -22,7 +22,7 @@ class AIClient(ABC):
         pass
 
     @abstractmethod
-    def streaming_call(self, messages: Message | message_thread, is_multi_npc: bool) -> AsyncGenerator[str | None, None]:
+    def streaming_call(self, messages: Message | message_thread, is_multi_npc: bool, current_context: Context) -> AsyncGenerator[str | None, None]:
         """A standard streaming call to the LLM. Forwards the output of 'client.chat.completions.create' 
         This method generates a new client, calls 'client.chat.completions.create' in a streaming way, yields the result immediately and closes when finished
 

--- a/src/llm/llm_test_client.py
+++ b/src/llm/llm_test_client.py
@@ -3,7 +3,7 @@ from src.llm.llm_model_list import LLMModelList
 from src.llm.ai_client import AIClient
 from src.llm.message_thread import message_thread
 from src.llm.messages import Message
-
+from opentelemetry.context.context import Context
 
 class LLMTestClient(AIClient):
     '''LLM class to handle NPC responses
@@ -12,7 +12,7 @@ class LLMTestClient(AIClient):
         self.__replies = replies
         self.__counter = 0
 
-    async def streaming_call(self, messages: Message | message_thread, is_multi_npc: bool) -> AsyncGenerator[str | None, None]:
+    async def streaming_call(self, messages: Message | message_thread, is_multi_npc: bool, current_context: Context) -> AsyncGenerator[str | None, None]:
         """A standard streaming call to the LLM. Forwards the output of 'client.chat.completions.create' 
         This method generates a new client, calls 'client.chat.completions.create' in a streaming way, yields the result immediately and closes when finished
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -7,6 +7,7 @@ import src.utils as utils
 import pandas as pd
 import sys
 from src.config.config_loader import ConfigLoader
+from src.telemetry.telemetry import get_telemetry_manager
 
 class MantellaSetup:
     def __init__(self):
@@ -14,7 +15,7 @@ class MantellaSetup:
         self.config = None
         self.language_info = {}
 
-    def initialise(self, config_file, logging_file, language_file) -> tuple[ConfigLoader, dict[Hashable, str]]:
+    def initialise(self, config_file, logging_file, language_file, mantella_version) -> tuple[ConfigLoader, dict[Hashable, str]]:
         '''Initialize Mantella with configuration, logging, and language settings'''
         self._set_cwd_to_exe_dir()
         self.save_folder = utils.get_my_games_directory(self._get_custom_user_folder())
@@ -36,7 +37,8 @@ class MantellaSetup:
         utils.cleanup_tmp(os.getenv('TMP')+'\\voicelines') # cleanup temp voicelines
 
         self.language_info = self._get_language_info(language_file, self.config.language)
-        
+        self._setup_telemetry(self.config, mantella_version)
+
         return self.config, self.language_info
 
     def _set_cwd_to_exe_dir(self):
@@ -117,3 +119,12 @@ class MantellaSetup:
         except:
             logging.error(f"Could not load language '{language}'. Please set a valid language in config.ini\n")
             return {}
+
+    def _setup_telemetry(self, config: ConfigLoader, version: str):
+        telemetry_manager = get_telemetry_manager()
+        enable_telemetry = getattr(config, 'enable_telemetry', False)
+        telemetry_manager.initialize(
+            config=config,
+            version=version,
+            enable_telemetry=enable_telemetry,
+        )

--- a/src/telemetry/telemetry.py
+++ b/src/telemetry/telemetry.py
@@ -1,0 +1,266 @@
+import os
+import logging
+import threading
+from typing import Dict, Any, Optional
+from dataclasses import dataclass, field
+from datetime import datetime
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.instrumentation.logging import LoggingInstrumentor
+
+
+@dataclass
+class TelemetryContext:
+    # Application metadata
+    application_name: str = "mantella"
+    application_version: str = ""
+    game_type: str = ""
+    mod_path: str = ""
+    telemetry_enabled: bool = False
+    
+    # User context
+    user_id: Optional[str] = None
+    session_id: Optional[str] = None
+    
+    # Runtime context
+    start_time: datetime = field(default_factory=datetime.now)
+    
+    # Custom attributes that can be added dynamically
+    custom_attributes: Dict[str, Any] = field(default_factory=dict)
+    
+    def to_resource_attributes(self) -> Dict[str, str]:
+        attributes = {
+            "service.name": self.application_name,
+            "service.version": self.application_version,
+            "game.type": str(self.game_type),
+        }
+        
+        if self.user_id:
+            attributes["user.id"] = self.user_id
+        if self.session_id:
+            attributes["session.id"] = self.session_id
+            
+        return attributes
+    
+    def add_custom_attribute(self, key: str, value: Any):
+        """Add a custom attribute to the context."""
+        self.custom_attributes[key] = value
+    
+    def get_all_attributes(self) -> Dict[str, Any]:
+        """Get all attributes including custom ones."""
+        base_attrs = self.to_resource_attributes()
+        base_attrs.update(self.custom_attributes)
+        return base_attrs
+
+
+class TelemetryManager:
+    # Singleton telemetry manager that provides global telemetry context.
+    
+    _instance = None
+    _lock = threading.Lock()
+    
+    def __new__(cls):
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+        return cls._instance
+    
+    def __init__(self):
+        if not hasattr(self, '_initialized'):
+            self._initialized = True
+            self._context = TelemetryContext()
+            self._tracer_provider = None
+            self._tracer = None
+            self._is_initialized = False
+    
+    @property
+    def context(self) -> TelemetryContext:
+        return self._context
+    
+    @property
+    def tracer(self):
+        if not self._is_initialized:
+            raise RuntimeError("TelemetryManager not initialized. Call initialize() first.")
+        return self._tracer
+    
+    def initialize(self, 
+                   config, 
+                   version: str,
+                   enable_telemetry: bool) -> None:
+        if self._is_initialized:
+            logging.warning("TelemetryManager already initialized")
+            return
+        
+        # Update context with config data if available
+        if config:
+            self._context.application_version = version
+            self._context.game_type = getattr(config, 'game', 'skyrim')
+            self._context.mod_path = getattr(config, 'mod_path', '')
+        
+        if not enable_telemetry:
+            logging.info("Telemetry disabled")
+            self._is_initialized = True
+            return        
+        
+        try:
+            self._setup_opentelemetry(config.telemetry_otlp_endpoint, config.telemetry_protocol)
+            self._is_initialized = True
+            self._context.telemetry_enabled = True
+            logging.info("Telemetry system initialized successfully")
+        except Exception as e:
+            logging.error(f"Failed to initialize telemetry: {e}")
+            self._is_initialized = True  # Mark as initialized to prevent retries
+    
+    def _setup_opentelemetry(self, endpoint: str, protocol: str):
+        # Header will contain the telemetry API key if using a SaaS provider
+        headers_str = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+        
+        # Parse headers
+        headers = {}
+        if headers_str:
+            for header in headers_str.split(","):
+                if "=" in header:
+                    key, value = header.split("=", 1)
+                    headers[key.strip()] = value.strip()
+        
+        # Format headers for HTTP
+        if headers:
+            formatted_headers = {}
+            for key, value in headers.items():
+                formatted_key = key.title().replace('_', '-')
+                formatted_headers[formatted_key] = value
+            headers = formatted_headers
+        
+        # Ensure endpoint has correct path
+        if not endpoint.endswith("/v1/traces"):
+            endpoint = endpoint.rstrip("/") + "/v1/traces"
+        
+        # Create resource with context attributes
+        resource = Resource.create(self._context.to_resource_attributes())
+        
+        # Create TracerProvider
+        self._tracer_provider = TracerProvider(resource=resource)
+        
+        if protocol == "http/protobuf":
+            if not endpoint.endswith("/v1/traces"):
+                endpoint = endpoint.rstrip("/") + "/v1/traces"
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+            otlp_exporter = OTLPSpanExporter(
+                endpoint=endpoint,
+                headers=headers if headers else None
+            )
+        elif protocol == "grpc":
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+            otlp_exporter = OTLPSpanExporter(
+                endpoint=endpoint,
+                headers=headers if headers else None
+            )
+        else:
+            raise ValueError(f"Unsupported telemetry protocol: {protocol}")
+
+
+        # Add BatchSpanProcessor
+        self._tracer_provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
+        
+        # Set as global default
+        trace.set_tracer_provider(self._tracer_provider)
+        
+        # Instrument common libraries
+        RequestsInstrumentor().instrument()
+        LoggingInstrumentor().instrument()
+        
+        # Create tracer
+        self._tracer = trace.get_tracer(self._context.application_name)
+        
+        logging.info(f"Telemetry configured with endpoint: {endpoint}")
+        logging.info(f"Resource attributes: {self._context.to_resource_attributes()}")
+    
+    def create_span(self, name: str, attributes: Optional[Dict[str, Any]] = None):
+        # Create a span with global context attributes.
+        if not self._is_initialized or not self._context.telemetry_enabled:
+            return _DummySpan()
+        
+        span_attributes = self._context.get_all_attributes().copy()
+        if attributes:
+            span_attributes.update(attributes)
+        
+        return self._tracer.start_as_current_span(name, attributes=span_attributes)
+    
+    def add_global_attribute(self, key: str, value: Any):
+        # Add an attribute that will be included in all future spans.
+        self._context.add_custom_attribute(key, value)
+    
+    def set_user_id(self, user_id: str):
+        # Set the user ID for all future telemetry.
+        self._context.user_id = user_id
+    
+    def set_session_id(self, session_id: str):
+        # Set the session ID for all future telemetry.
+        self._context.session_id = session_id
+    
+    def get_uptime_seconds(self) -> float:
+        # Get application uptime in seconds.
+        return (datetime.now() - self._context.start_time).total_seconds()
+
+
+class _DummySpan:
+    # Dummy span for when telemetry is disabled.
+    
+    def __enter__(self):
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+    
+    def set_attribute(self, key: str, value: Any):
+        pass
+    
+    def add_event(self, name: str, attributes: Optional[Dict[str, Any]] = None):
+        pass
+    
+    def record_exception(self, exception: Exception):
+        pass
+
+
+# Global instance
+telemetry_manager = TelemetryManager()
+
+# Convenience functions
+
+def get_telemetry_manager() -> TelemetryManager:
+    """Get the global telemetry manager instance."""
+    return telemetry_manager
+
+
+def create_span(name: str, attributes: Optional[Dict[str, Any]] = None):
+    """Convenience function to create a span with global context."""
+    return telemetry_manager.create_span(name, attributes)
+
+
+def create_span_with_parent(name: str, parent_context, attributes: Optional[Dict[str, Any]] = None):
+    """Create a span with a specific parent context (useful for cross-thread operations)."""
+    if not telemetry_manager._is_initialized or not telemetry_manager._context.telemetry_enabled:
+        return _DummySpan()
+    
+    span_attributes = telemetry_manager._context.get_all_attributes().copy()
+    if attributes:
+        span_attributes.update(attributes)
+    
+    from opentelemetry import context as otel_context
+    from opentelemetry import trace as otel_trace
+    
+    if hasattr(parent_context, 'span_id'):  # It's a SpanContext
+        ctx = otel_context.set_span_context(otel_context.get_current(), parent_context)
+    else:
+        ctx = parent_context
+    
+    return telemetry_manager._tracer.start_as_current_span(name, context=ctx, attributes=span_attributes)
+
+
+def add_global_attribute(key: str, value: Any):
+    """Convenience function to add global attributes."""
+    telemetry_manager.add_global_attribute(key, value)

--- a/tests/llm/test_llm_client.py
+++ b/tests/llm/test_llm_client.py
@@ -85,7 +85,7 @@ def test_sync_call(llm_client: LLMClient, example_system_message: SystemMessage)
 async def test_async_call(llm_client: LLMClient, example_system_message: SystemMessage):
     response = ''
     # Single NPC
-    async for content in llm_client.streaming_call(messages=example_system_message, is_multi_npc=False):
+    async for content in llm_client.streaming_call(messages=example_system_message, is_multi_npc=False, current_context=None):
         if content is not None:
             response += content
     assert response is not None
@@ -93,7 +93,7 @@ async def test_async_call(llm_client: LLMClient, example_system_message: SystemM
 
     response = ''
     # Multi NPC
-    async for content in llm_client.streaming_call(messages=example_system_message, is_multi_npc=True):
+    async for content in llm_client.streaming_call(messages=example_system_message, is_multi_npc=True, current_context=None):
         if content is not None:
             response += content
     assert response is not None


### PR DESCRIPTION
This adds support for using opentelemetry to trace server function calls. 

There is a new config section. Set `enable_telemetry = True` to turn on, and set the appropriate config depending on your provider (the one for Grafana is set as the default). If your provider requires an API key, this should be set via the environment variable `OTEL_EXPORTER_OTLP_HEADERS` in the format `Authorization=Basic%20xxx`:

```
[Telemetry]
; Telemetry settings.

;   Enable open telemetry for tracing
;   enable_telemetry must either be 'True' or 'False'
;   default = False
enable_telemetry = True

;   Open Telemetry endpoint
telemetry_otlp_endpoint = https://otlp-gateway-prod-gb-south-1.grafana.net/otlp

;   Open Telemetry protocol (can be 'http/protobuf' or 'grpc')
;   default = http/protobuf
telemetry_protocol = http/protobuf
```

Once enabled, functions decorated with `@utils.time_it` will create tracing spans and send them to the configured opentelemetry server, instead of just dumping timing results to the console.

Example (grafana) call heirarchy:
<img width="1275" height="835" alt="image" src="https://github.com/user-attachments/assets/881f2271-6126-4ca8-ab95-52092f74582e" />

Notes
- cross-thread calls are supported, but should use `with create_span_with_parent(name, current_context) as span:` passing in the context from the caller to the async call. if this is skipped, the trace will not be attached to the parent context

Known issue:
- use with the `yeild` statement can still cause errors to be logged by opentelemetry e.g. `ValueError: <Token var=<ContextVar name='current_context' default={} at 0x000001D1CE42AF70> at 0x000001D1A9E1E940> was created in a different Context`. Requires investigation, but doesn't seem to cause any issues other than excess logging.

