### PR TITLE
Disable fast responses in radiant dialogue

### DIFF
--- a/src/games/skyrim.py
+++ b/src/games/skyrim.py
@@ -178,7 +178,8 @@ class Skyrim(Gameable):
         if topicID == 2:
             filename = self.DIALOGUELINE2_FILENAME
         
-        if config.fast_response_mode and isFirstLine:
+        # Play audio immediately if fast response mode is enabled, this is the first line of the response, and the conversation isn't radiant
+        if config.fast_response_mode and isFirstLine and context_of_conversation.npcs_in_conversation.contains_player_character():
             self.play_audio_async(audio_file, volume=config.fast_response_mode_volume/100)
             self.send_muted_voiceline_to_game_folder(audio_file, filename, voice_folder_path)
         else:

--- a/tests/games/test_skyrim.py
+++ b/tests/games/test_skyrim.py
@@ -6,6 +6,7 @@ from src.llm.sentence_content import SentenceContent
 from src.llm.sentence_content import SentenceTypeEnum
 from src.games.external_character_info import external_character_info
 from src.character_manager import Character
+from src.conversation.context import Context
 import shutil
 import os
 import json
@@ -269,7 +270,7 @@ def test_load_external_character_info(skyrim: Skyrim):
     assert info.bio == "You are a male Nord Unknown Character."
 
 
-def test_prepare_sentence_for_game(tmp_path, skyrim: Skyrim, default_config: ConfigLoader, example_skyrim_npc_character: Character):
+def test_prepare_sentence_for_game(tmp_path, skyrim: Skyrim, default_config: ConfigLoader, example_skyrim_npc_character: Character, default_context: Context):
     """Test that prepare_sentence_for_game correctly processes audio files based on configuration"""
     default_config.save_audio_data_to_character_folder = False
     default_config.fast_response_mode = False
@@ -302,7 +303,7 @@ def test_prepare_sentence_for_game(tmp_path, skyrim: Skyrim, default_config: Con
     # Test 1: Default behavior with topicID 1    
     skyrim.prepare_sentence_for_game(
         queue_output = example_sentence, 
-        context_of_conversation = None, 
+        context_of_conversation = default_context, 
         config = default_config, 
         topicID = 1, 
         isFirstLine = False,
@@ -318,7 +319,7 @@ def test_prepare_sentence_for_game(tmp_path, skyrim: Skyrim, default_config: Con
     # Test 2: Different topicID
     skyrim.prepare_sentence_for_game(
         queue_output = example_sentence, 
-        context_of_conversation = None, 
+        context_of_conversation = default_context, 
         config = default_config,
         topicID = 2,
         isFirstLine = False,
@@ -337,7 +338,7 @@ def test_prepare_sentence_for_game(tmp_path, skyrim: Skyrim, default_config: Con
 
     skyrim.prepare_sentence_for_game(
         queue_output = example_sentence, 
-        context_of_conversation = None, 
+        context_of_conversation = default_context, 
         config = default_config,
         topicID = 1,
         isFirstLine = True, # isFirstLine determines whether a fast response should play


### PR DESCRIPTION
Mantella's fast response mode plays the first voiceline of each response directly from the exe. Because of this, there is no directional audio for the voicelines. This works in single and group conversations, where the player is likely to be facing the NPC(s), but for radiant conversations NPCs are often standing further away from the player. This makes it jarring when voicelines play directly from the exe as if the NPC is standing in front of the player.