### PR TITLE
Track days passed in starting prompts and conversation summaries

### DIFF
--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -303,6 +303,7 @@ LLM parameter list must follow the Python dictionary format: https://www.w3schoo
             self.radiant_end_prompt = self.__definitions.get_string_value("radiant_end_prompt")
             self.radiant_max_turns = self.__definitions.get_int_value("radiant_max_turns")
             self.memory_prompt = self.__definitions.get_string_value("memory_prompt")
+            self.memory_prompt_datetime_prefix = self.__definitions.get_bool_value("memory_prompt_datetime_prefix")
             self.resummarize_prompt = self.__definitions.get_string_value("resummarize_prompt")
             self.vision_prompt = self.__definitions.get_string_value("vision_prompt")
             self.function_llm_prompt = self.__definitions.get_string_value("function_llm_prompt")

--- a/src/config/definitions/prompt_definitions.py
+++ b/src/config/definitions/prompt_definitions.py
@@ -3,6 +3,7 @@ from regex import Regex
 from src.config.types.config_value import ConfigValue
 from src.config.types.config_value_int import ConfigValueInt
 from src.config.types.config_value_string import ConfigValueString
+from src.config.types.config_value_bool import ConfigValueBool
 from src.config.config_value_constraint import ConfigValueConstraint, ConfigValueConstraintResult
 
 
@@ -20,7 +21,8 @@ class PromptDefinitions:
                                 "equipment",
                                 "location",
                                 "weather",
-                                "time", 
+                                "time",
+                                "current_day",
                                 "time_group", 
                                 "language", 
                                 "conversation_summary",
@@ -36,7 +38,8 @@ class PromptDefinitions:
                                 "equipment",
                                 "location",
                                 "weather",
-                                "time", 
+                                "time",
+                                "current_day",
                                 "time_group", 
                                 "language", 
                                 "conversation_summary",
@@ -106,7 +109,7 @@ class PromptDefinitions:
                                 Who do you think these belong to?
                                 You are having a conversation with {player_name} (the player) who is {trust} in {location}. {player_name} {player_description} {player_equipment} {equipment}
                                 This conversation is a script that will be spoken aloud, so please keep your responses appropriately concise and avoid text-only formatting such as numbered lists.
-                                The time is {time} {time_group}.
+                                The time is {time} {time_group} on Day {current_day}.
                                 {weather}
                                 Remember to stay in character.
                                 {actions}
@@ -122,7 +125,7 @@ class PromptDefinitions:
                                     {equipment}
                                     And here are their conversation histories: 
                                     {conversation_summaries}
-                                    The time is {time} {time_group}.
+                                    The time is {time} {time_group} on Day {current_day}.
                                     {weather}
                                     You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'.
                                     Please use your own discretion to decide who should speak in a given situation (sometimes responding with all NPCs is suitable).
@@ -137,7 +140,7 @@ class PromptDefinitions:
                                     Here are their backgrounds: 
                                     {bios}                                    
                                     {conversation_summaries}
-                                    The time is {time} {time_group}.
+                                    The time is {time} {time_group} on Day {current_day}.
                                     {weather}
                                     You are tasked with providing the responses for the NPCs. Please begin your response with an indication of who you are speaking as, for example: '{name}: Good evening.'. 
                                     Please use your own discretion to decide who should speak in a given situation (sometimes responding with all NPCs is suitable). 
@@ -198,6 +201,11 @@ class PromptDefinitions:
         return ConfigValueString("memory_prompt","Memory Prompt",memory_prompt_description,memory_prompt,[PromptDefinitions.PromptChecker(["name", "language", "game"])])
     
     @staticmethod
+    def get_memory_prompt_datetime_prefix_config_value() -> ConfigValue:
+        description = """Whether to prepend a timestamp of when the conversation took place (eg "[Day 42, 5 in the early evening]") to the summary."""
+        return ConfigValueBool("memory_prompt_datetime_prefix","Memory Prompt Datetime Prefix",description,True)
+    
+    @staticmethod
     def get_resummarize_prompt_config_value() -> ConfigValue:
         resummarize_prompt_description = """Memories build up over time in data/game/conversations/NPC_Name/NPC_Name_summary_X.txt.
                                             When these memories become too long to fit into the chosen LLM's maximum context length, these memories need to be condensed down.
@@ -207,7 +215,7 @@ class PromptDefinitions:
                                                 language = the selected language
                                                 game = the game selected""" 
         resummarize_prompt = """You are tasked with summarizing the conversation history between {name} (the assistant) and the player (the user) / other characters. These conversations take place in {game}.
-                                            Each paragraph represents a conversation at a new point in time. Please summarize these conversations into a single paragraph in {language}."""
+                                            Each paragraph represents a conversation at a new point in time. Timestamps in square brackets (eg [Day 42, 5 in the early evening]) indicate when each conversation occurred. Please summarize these conversations into a single paragraph in {language}."""
         return ConfigValueString("resummarize_prompt","Resummarize Prompt",resummarize_prompt_description,resummarize_prompt,[PromptDefinitions.PromptChecker(["name", "language", "game"])])
     
     @staticmethod

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -146,6 +146,7 @@ class MantellaConfigValueDefinitionsNew:
         prompts_category.add_config_value(PromptDefinitions.get_fallout4_multi_npc_prompt_config_value())
         prompts_category.add_config_value(PromptDefinitions.get_fallout4_radiant_prompt_config_value())
         prompts_category.add_config_value(PromptDefinitions.get_memory_prompt_config_value())
+        prompts_category.add_config_value(PromptDefinitions.get_memory_prompt_datetime_prefix_config_value())
         prompts_category.add_config_value(PromptDefinitions.get_resummarize_prompt_config_value())
         prompts_category.add_config_value(PromptDefinitions.get_vision_prompt_config_value())
         prompts_category.add_config_value(PromptDefinitions.get_function_llm_prompt_config_value())

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -31,6 +31,7 @@ class Context:
         self.__config_settings: dict[str, Any] = {}
         self.__custom_context_values: dict[str, Any] = {}
         self.__ingame_time: int = 12
+        self.__game_days: float = 1.0  # Full game timestamp (days.fraction)
         self.__ingame_events: list[str] = []
         self.__vision_hints: str = ''
         self.__have_actors_changed: bool = False
@@ -164,8 +165,12 @@ class Context:
         return get_time_group(self.__ingame_time)
     
     @utils.time_it
-    def update_context(self, location: str | None, in_game_time: int | None, custom_ingame_events: list[str] | None, weather: str | None, npcs_nearby: list[dict[str, Any]] | None, custom_context_values: dict[str, Any], config_settings: dict[str, Any] | None):
+    def update_context(self, location: str | None, in_game_time: int | None, custom_ingame_events: list[str] | None, weather: str | None, npcs_nearby: list[dict[str, Any]] | None, custom_context_values: dict[str, Any], config_settings: dict[str, Any] | None, game_days: float | None = None):
         self.__custom_context_values = custom_context_values
+
+        # Store game_days if provided
+        if game_days is not None:
+            self.__game_days = game_days
 
         if location:
             if location != '':
@@ -430,6 +435,10 @@ class Context:
         weather = self.__weather
         time = self.__ingame_time - 12 if self.__ingame_time > 12 else self.__ingame_time
         time_group = get_time_group(self.__ingame_time)
+        
+        # Calculate current day number from game_days
+        current_day = int(self.__game_days) if self.__game_days > 1 else 1
+        
         if self.__hourly_time:
             self.__prev_game_time = str(time), time_group
         else:
@@ -457,7 +466,8 @@ class Context:
                 equipment = equipment,
                 location=location,
                 weather = weather,
-                time=time, 
+                time=time,
+                current_day=current_day,
                 time_group=time_group, 
                 language=self.__language['language'], 
                 conversation_summary=content[1],

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -187,7 +187,9 @@ class GameStateManager:
     @utils.time_it
     def end_conversation(self, input_json: dict[str, Any]) -> dict[str, Any]:
         if(self.__talk):
-            self.__talk.end()
+            # Extract end timestamp from game client
+            end_timestamp = input_json.get(comm_consts.KEY_ENDCONVERSATION_TIMESTAMP, None)
+            self.__talk.end(end_timestamp)
             self.__talk = None
 
         logging.log(24, '\nConversations not starting when you select an NPC? See here:')
@@ -252,6 +254,7 @@ class GameStateManager:
             
             location = None
             time = None
+            game_days = None
             ingame_events = None
             weather = None
             npcs_nearby = None
@@ -263,6 +266,9 @@ class GameStateManager:
                 
                 if json[comm_consts.KEY_CONTEXT].__contains__(comm_consts.KEY_CONTEXT_TIME):
                     time: int = json[comm_consts.KEY_CONTEXT][comm_consts.KEY_CONTEXT_TIME]
+
+                if json[comm_consts.KEY_CONTEXT].__contains__(comm_consts.KEY_CONTEXT_GAMEDAYS):
+                    game_days: float = json[comm_consts.KEY_CONTEXT][comm_consts.KEY_CONTEXT_GAMEDAYS]
 
                 if json[comm_consts.KEY_CONTEXT].__contains__(comm_consts.KEY_CONTEXT_INGAMEEVENTS):
                     logging.log(23, f'Received in-game events: {json[comm_consts.KEY_CONTEXT][comm_consts.KEY_CONTEXT_INGAMEEVENTS]}')
@@ -280,7 +286,7 @@ class GameStateManager:
                 if json[comm_consts.KEY_CONTEXT].__contains__(comm_consts.KEY_CONTEXT_CUSTOMVALUES):
                     custom_context_values = json[comm_consts.KEY_CONTEXT][comm_consts.KEY_CONTEXT_CUSTOMVALUES]
 
-                self.__talk.update_context(location, time, ingame_events, weather, npcs_nearby, custom_context_values, config_settings)
+                self.__talk.update_context(location, time, ingame_events, weather, npcs_nearby, custom_context_values, config_settings, game_days)
     
     @utils.time_it
     def load_character(self, json: dict[str, Any]) -> Character | None:

--- a/src/http/communication_constants.py
+++ b/src/http/communication_constants.py
@@ -22,6 +22,7 @@ class communication_constants:
 
     KEY_STARTCONVERSATION_WORLDID: str = PREFIX + "worldid"
     KEY_STARTCONVERSATION_USENARRATOR: str = PREFIX + "use_narrator"
+    KEY_ENDCONVERSATION_TIMESTAMP: str = PREFIX + "end_timestamp"
     KEY_CONTINUECONVERSATION_TOPICINFOFILE: str = PREFIX + "topicinfofile"
     KEY_INPUTTYPE: str = PREFIX + "input_type"
     KEY_INPUTTYPE_MIC: str = PREFIX + "mic_input"
@@ -64,6 +65,7 @@ class communication_constants:
     KEY_CONTEXT_LOCATION: str = PREFIX + "location"
     KEY_CONTEXT_WEATHER = PREFIX + "weather"
     KEY_CONTEXT_TIME: str = PREFIX + "time"
+    KEY_CONTEXT_GAMEDAYS: str = PREFIX + "gamedays"
     KEY_CONTEXT_NPCS_NEARBY: str = PREFIX + "nearby_actors"
     KEY_CONTEXT_INGAMEEVENTS: str = PREFIX + "ingame_events"
     KEY_CONTEXT_CONFIG_SETTINGS: str = PREFIX + "config_settings"


### PR DESCRIPTION
- Added a toggleable option to the `Prompts` tab in the Mantella UI to prepend each summary with a timestamp in the format "[Day 42, 5 in the evening]" to help track when conversations take place
- Added the day number to each starting prompt