### PR TITLE
Add advanced secret key management JSON file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ data/**/*.txt
 !data/Fallout4/placeholder/*.lip
 data/tmp/
 *SECRET_KEY.txt
+secret_keys.json
 logging.log
 player_recording.wav
 MantellaEnv*

--- a/main.py
+++ b/main.py
@@ -24,10 +24,6 @@ def main():
         should_debug_http = config.show_http_debug_messages
         conversation = mantella_route(
             config=config, 
-            stt_secret_key_file='STT_SECRET_KEY.txt', 
-            image_secret_key_file='IMAGE_SECRET_KEY.txt', 
-            function_llm_secret_key_file='FUNCTION_GPT_SECRET_KEY.txt',
-            secret_key_file='GPT_SECRET_KEY.txt', 
             language_info=language_info, 
             show_debug_messages=should_debug_http
         )

--- a/src/config/definitions/stt_definitions.py
+++ b/src/config/definitions/stt_definitions.py
@@ -111,7 +111,7 @@ class STTDefinitions:
     @staticmethod
     def get_whisper_url_config_value() -> ConfigValue:
         description = """The external Whisper service URL Mantella will connect to (if 'External Whisper Service' is enabled). 
-                        Some services require an API secret key. This secret key either needs to be set in your `GPT_SECRET_KEY.txt` file, or by creating a new text file called `STT_SECRET_KEY.txt` in the same folder as `GPT_SECRET_KEY.txt` and adding the API key there. If you don't see the service you would like to connect to in the dropdown list, you can also manually enter a URL to connect to.
+                        Some services require an API secret key. This secret key can be set in your `GPT_SECRET_KEY.txt` file. If you don't see the service you would like to connect to in the dropdown list, you can also manually enter a URL to connect to.
                         
                         Known services:
 	                        OpenAI: Ensure 'Speech-to-Text'->'Model Size' is set to `whisper-1`. Requires an OpenAI secret key.

--- a/src/config/definitions/vision_definitions.py
+++ b/src/config/definitions/vision_definitions.py
@@ -53,7 +53,7 @@ class VisionDefinitions:
             If you are connecting to a local service (KoboldCpp, textgenwebui etc), please ensure that the service is running and a model is loaded. You can also enter a custom URL to connect to other LLM services that provide an OpenAI compatible endpoint.
             After selecting a service, select the model using the option below. Press the *Update* button to load a list of models available from the service.
 
-            Some services require an API secret key. This secret key either needs to be set in your `GPT_SECRET_KEY.txt` file, or by creating a new text file called `IMAGE_SECRET_KEY.txt` in the same folder as `GPT_SECRET_KEY.txt` and adding the API key there."""
+            Some services require an API secret key. This secret key can be set in your `GPT_SECRET_KEY.txt` file."""
         options = ["OpenRouter", "OpenAI", "KoboldCpp", "textgenwebui"]
         return ConfigValueSelection("vision_llm_api", "Custom Vision Model Service", description, "OpenRouter", options, allows_free_edit=True, tags=[ConfigValueTag.advanced])
     

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -31,7 +31,7 @@ class GameStateManager:
     WORLD_ID_CLEANSE_REGEX: regex.Pattern = regex.compile('[^A-Za-z0-9]+')
 
     @utils.time_it
-    def __init__(self, game: Gameable, chat_manager: ChatManager, config: ConfigLoader, language_info: dict[Hashable, str], client: LLMClient, stt_api_file: str, api_file: str):        
+    def __init__(self, game: Gameable, chat_manager: ChatManager, config: ConfigLoader, language_info: dict[Hashable, str], client: LLMClient):        
         self.__game: Gameable = game
         self.__config: ConfigLoader = config
         self.__language_info: dict[Hashable, str] = language_info 
@@ -41,8 +41,6 @@ class GameStateManager:
         self.__talk: Conversation | None = None
         self.__mic_input: bool = False
         self.__mic_ptt: bool = False # push-to-talk
-        self.__stt_api_file: str = stt_api_file
-        self.__api_file: str = api_file
         self.__stt: Transcriber | None = None
         self.__first_line: bool = True
         self.__automatic_greeting: bool = config.automatic_greeting
@@ -205,7 +203,7 @@ class GameStateManager:
             self.__mic_input = True
             # only init Transcriber if mic input is enabled
             if not self.__stt:
-                self.__stt = Transcriber(self.__config, self.__stt_api_file, self.__api_file)
+                self.__stt = Transcriber(self.__config)
             if input_json[comm_consts.KEY_INPUTTYPE] == comm_consts.KEY_INPUTTYPE_PTT:
                 self.__mic_ptt = True
         else:

--- a/src/http/routes/mantella_route.py
+++ b/src/http/routes/mantella_route.py
@@ -29,13 +29,9 @@ class mantella_route(routeable):
     Args:
         routeable (_type_): _description_
     """
-    def __init__(self, config: ConfigLoader, stt_secret_key_file: str, image_secret_key_file: str, function_llm_secret_key_file: str, secret_key_file: str, language_info: dict[Hashable, str], show_debug_messages: bool = False) -> None:
+    def __init__(self, config: ConfigLoader, language_info: dict[Hashable, str], show_debug_messages: bool = False) -> None:
         super().__init__(config, show_debug_messages)
         self.__language_info: dict[Hashable, str] = language_info
-        self.__secret_key_file: str = secret_key_file
-        self.__function_llm_secret_key_file: str = function_llm_secret_key_file
-        self.__stt_secret_key_file: str = stt_secret_key_file
-        self.__image_secret_key_file: str = image_secret_key_file
         self.__game: GameStateManager | None = None
 
         # if not self._can_route_be_used():
@@ -62,10 +58,10 @@ class mantella_route(routeable):
         if self._config.tts_service == TTSEnum.PIPER:
             tts = Piper(self._config, game)
 
-        llm_client = LLMClient(self._config, self.__secret_key_file, self.__image_secret_key_file, self.__function_llm_secret_key_file)
+        llm_client = LLMClient(self._config)
         
         chat_manager = ChatManager(self._config, tts, llm_client)
-        self.__game = GameStateManager(game, chat_manager, self._config, self.__language_info, llm_client, self.__stt_secret_key_file, self.__secret_key_file)
+        self.__game = GameStateManager(game, chat_manager, self._config, self.__language_info, llm_client)
 
     @utils.time_it
     def add_route_to_server(self, app: FastAPI):

--- a/src/llm/ai_client.py
+++ b/src/llm/ai_client.py
@@ -51,12 +51,11 @@ class AIClient(ABC):
 
     @staticmethod
     @abstractmethod
-    def get_model_list(service: str, secret_key_file: str, default_model: str = "mistralai/mistral-small-3.1-24b-instruct:free", is_vision: bool = False, is_tool_calling: bool = False) -> LLMModelList:
+    def get_model_list(service: str, default_model: str = "mistralai/mistral-small-3.1-24b-instruct:free", is_vision: bool = False, is_tool_calling: bool = False) -> LLMModelList:
         """Returns a list of available LLM models
 
         Args:
             service (str): the service to query for LLM models
-            secret_key_file (str): _description_
             default_model (_type_, optional): _description_. Defaults to "mistralai/mistral-small-3.1-24b-instruct:free".
             is_vision (bool, optional): _description_. Defaults to False.
             is_tool_calling (bool, optional): _description_. Defaults to False.

--- a/src/llm/function_client.py
+++ b/src/llm/function_client.py
@@ -14,7 +14,7 @@ class FunctionClient(ClientBase):
     '''LLM class to handle function calling / actions
     '''
     @utils.time_it
-    def __init__(self, config: ConfigLoader, secret_key_file: str, function_llm_secret_key_file: str) -> None:
+    def __init__(self, config: ConfigLoader) -> None:
         self.__config = config
         self.__function_prompt: str = config.function_llm_prompt.format(game=config.game.display_name)
         
@@ -26,7 +26,7 @@ class FunctionClient(ClientBase):
             'custom_token_count': config.function_llm_custom_token_count
         }
         
-        super().__init__(**setup_values, secret_key_files=[function_llm_secret_key_file, secret_key_file])
+        super().__init__(**setup_values)
 
         if self._is_local:
             logger.info(f"Running local tool calling model")

--- a/src/llm/image_client.py
+++ b/src/llm/image_client.py
@@ -13,7 +13,7 @@ class ImageClient(ClientBase):
     '''Image class to handle LLM vision
     '''
     @utils.time_it
-    def __init__(self, config: ConfigLoader, secret_key_file: str, image_secret_key_file: str) -> None:
+    def __init__(self, config: ConfigLoader) -> None:
         self.__config = config    
         self.__custom_vision_model: bool = config.custom_vision_model
 
@@ -22,7 +22,7 @@ class ImageClient(ClientBase):
         else: # default to base LLM config values
             setup_values = {'api_url': config.llm_api, 'llm': config.llm, 'llm_params': config.llm_params, 'custom_token_count': config.custom_token_count}
         
-        super().__init__(**setup_values, secret_key_files=[image_secret_key_file, secret_key_file])
+        super().__init__(**setup_values)
 
         if self.__custom_vision_model:
             if self._is_local:

--- a/src/llm/llm_client.py
+++ b/src/llm/llm_client.py
@@ -12,8 +12,8 @@ class LLMClient(ClientBase):
     '''LLM class to handle NPC responses
     '''
     @utils.time_it
-    def __init__(self, config: ConfigLoader, secret_key_file: str, image_secret_key_file: str, function_secret_key_file: str = None) -> None:
-        super().__init__(config.llm_api, config.llm, config.llm_params, config.custom_token_count, [secret_key_file])
+    def __init__(self, config: ConfigLoader) -> None:
+        super().__init__(config.llm_api, config.llm, config.llm_params, config.custom_token_count)
 
         if self._is_local:
             logger.info(f"Running Mantella with local language model")
@@ -24,12 +24,12 @@ class LLMClient(ClientBase):
 
         if config.vision_enabled:
             logger.info(f"Setting up vision language model...")
-            self._image_client: ImageClient | None = ImageClient(config, secret_key_file, image_secret_key_file)
+            self._image_client: ImageClient | None = ImageClient(config)
 
         if config.advanced_actions_enabled and config.custom_function_model:
             try:
                 logger.info(f"Setting up tool calling language model...")
-                self._function_client: FunctionClient | None = FunctionClient(config, secret_key_file, function_secret_key_file)
+                self._function_client: FunctionClient | None = FunctionClient(config)
             except Exception as e:
                 logger.error(f"Failed to initialize function calling LLM: {e}. Tool calling will be disabled.")
                 self._function_client = None

--- a/src/llm/llm_test_client.py
+++ b/src/llm/llm_test_client.py
@@ -55,12 +55,11 @@ class LLMTestClient(AIClient):
         return False
 
     @staticmethod
-    def get_model_list(service: str, secret_key_file: str, default_model: str = "mistralai/mistral-small-3.1-24b-instruct:free", is_vision: bool = False) -> LLMModelList:
+    def get_model_list(service: str, default_model: str = "mistralai/mistral-small-3.1-24b-instruct:free", is_vision: bool = False, is_tool_calling: bool = False) -> LLMModelList:
         """Returns a list of available LLM models
 
         Args:
             service (str): the service to query for LLM models
-            secret_key_file (str): _description_
             default_model (_type_, optional): _description_. Defaults to "mistralai/mistral-small-3.1-24b-instruct:free".
             is_vision (bool, optional): _description_. Defaults to False.
 

--- a/src/stt.py
+++ b/src/stt.py
@@ -2,6 +2,7 @@ import sys
 import numpy as np
 from faster_whisper import WhisperModel
 from src.config.config_loader import ConfigLoader
+from src.llm.client_base import ClientBase
 import src.utils as utils
 import requests
 import json
@@ -37,7 +38,7 @@ class Transcriber:
     LOOKBACK_CHUNKS = 5  # Number of chunks to keep in buffer when not recording
     
     @utils.time_it
-    def __init__(self, config: ConfigLoader, stt_secret_key_file: str, secret_key_file: str):
+    def __init__(self, config: ConfigLoader):
         self.loglevel = 27
         self.language = config.stt_language
         self.task = "translate" if config.stt_translate == 1 else "transcribe"
@@ -74,8 +75,7 @@ class Transcriber:
             self.__mic_input_path: str = config.save_folder+'data\\tmp\\mic'
             os.makedirs(self.__mic_input_path, exist_ok=True)
 
-        self.__stt_secret_key_file = stt_secret_key_file
-        self.__secret_key_file = secret_key_file
+        self.__stt_service_name = config.whisper_url
         self.__api_key: str | None = self.__get_api_key()
         self.__initial_client: OpenAI | None = None
         if (self.stt_service == 'whisper') and (self.__api_key) and ('openai' in self.whisper_url) and (self.external_whisper_service):
@@ -187,23 +187,8 @@ class Transcriber:
     @utils.time_it
     def __get_api_key(self) -> str:
         if self.external_whisper_service:
-            try: # first check mod folder for stt secret key
-                mod_parent_folder = str(Path(utils.resolve_path()).parent.parent.parent)
-                with open(mod_parent_folder+'\\'+self.__stt_secret_key_file, 'r') as f:
-                    api_key: str = f.readline().strip()
-            except: # check locally (same folder as exe) for stt secret key
-                try:
-                    with open(self.__stt_secret_key_file, 'r') as f:
-                        api_key: str = f.readline().strip()
-                except:
-                    try: # first check mod folder for secret key
-                        mod_parent_folder = str(Path(utils.resolve_path()).parent.parent.parent)
-                        with open(mod_parent_folder+'\\'+self.__secret_key_file, 'r') as f:
-                            api_key: str = f.readline().strip()
-                    except: # check locally (same folder as exe) for secret key
-                        with open(self.__secret_key_file, 'r') as f:
-                            api_key: str = f.readline().strip()
-                
+            api_key = ClientBase._get_api_key(self.__stt_service_name, show_error=False)
+            
             if not api_key:
                 logger.error(f'''No secret key found in GPT_SECRET_KEY.txt. Please create a secret key and paste it in your Mantella mod folder's GPT_SECRET_KEY.txt file.
 If using OpenAI, see here on how to create a secret key: https://help.openai.com/en/articles/4936850-where-do-i-find-my-openai-api-key

--- a/src/ui/settings_ui_constructor.py
+++ b/src/ui/settings_ui_constructor.py
@@ -293,19 +293,16 @@ class SettingsUIConstructor(ConfigValueVisitor):
         special_handlers: Dict[str, ModelConfig] = {
             "model": {
                 "dependent_config": "llm_api",
-                "secret_key_file": 'GPT_SECRET_KEY.txt',
                 "default_model": 'mistralai/mistral-small-3.1-24b-instruct:free',
                 "model_list_getter": ClientBase.get_model_list,
             },
             "vision_model": {
                 "dependent_config": "vision_llm_api",
-                "secret_key_file": 'IMAGE_SECRET_KEY.txt',
                 "default_model": 'google/gemma-3-27b-it:free',
                 "model_list_getter": ClientBase.get_model_list,
             },
             "function_llm": {
                 "dependent_config": "function_llm_api",
-                "secret_key_file": 'FUNCTION_GPT_SECRET_KEY.txt',
                 "default_model": 'mistralai/mistral-small-3.1-24b-instruct:free',
                 "model_list_getter": ClientBase.get_model_list,
             }
@@ -322,11 +319,10 @@ class SettingsUIConstructor(ConfigValueVisitor):
             handler = special_handlers.get(config_value.identifier)
             if handler:
                 service: str = self.__identifier_to_config_value[handler["dependent_config"]].value
-                secret_key_file = handler.get("secret_key_file", 'GPT_SECRET_KEY.txt')
                 default_model = handler.get("default_model", 'mistralai/mistral-small-3.1-24b-instruct:free')
                 is_vision = True if config_value.identifier == 'vision_model' else False
                 is_tool_calling = True if config_value.identifier == 'function_llm' else False
-                model_list = handler["model_list_getter"](service, secret_key_file, default_model, is_vision, is_tool_calling)
+                model_list = handler["model_list_getter"](service, default_model, is_vision, is_tool_calling)
                 selected_model = config_value.value
                 
                 if not model_list.is_model_in_list(selected_model):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,13 +65,13 @@ def piper(default_config: ConfigLoader, skyrim: Skyrim) -> Piper:
 
 @pytest.fixture
 def llm_client(default_config: ConfigLoader) -> LLMClient:
-    return LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    return LLMClient(default_config)
 
 @pytest.fixture
 def default_function_client(default_config: ConfigLoader) -> FunctionClient:
     """Provides a FunctionClient instance for testing"""
     FunctionManager.load_all_actions() # This is called on server startup, but not when creating the client standalone
-    return FunctionClient(default_config, "GPT_SECRET_KEY.txt", "FUNCTION_SECRET_KEY.txt")
+    return FunctionClient(default_config)
 
 @pytest.fixture
 def default_rememberer(skyrim: Skyrim, default_config: ConfigLoader, llm_client: LLMClient, english_language_info: dict) -> Summaries:
@@ -97,7 +97,7 @@ def default_conversation(default_context: Context, default_chat_manager: ChatMan
 
 @pytest.fixture
 def default_game_manager(skyrim: Skyrim, default_chat_manager: ChatManager, default_config: ConfigLoader, english_language_info: dict, llm_client: LLMClient) -> GameStateManager:
-    return GameStateManager(skyrim, default_chat_manager, default_config, english_language_info, llm_client, "STT_SECRET_KEY.txt", "GPT_SECRET_KEY.txt")
+    return GameStateManager(skyrim, default_chat_manager, default_config, english_language_info, llm_client)
 
 @pytest.fixture
 def server() -> http_server:
@@ -108,10 +108,6 @@ def server() -> http_server:
 def default_mantella_route(default_config: ConfigLoader, english_language_info: dict) -> mantella_route:
     return mantella_route(
         config=default_config, 
-        stt_secret_key_file='STT_SECRET_KEY.txt', 
-        image_secret_key_file='IMAGE_SECRET_KEY.txt',
-        function_llm_secret_key_file='FUNCTION_GPT_SECRET_KEY.txt',
-        secret_key_file='GPT_SECRET_KEY.txt', 
         language_info=english_language_info, 
         show_debug_messages=False
     )

--- a/tests/http/routes/test_mantella_route.py
+++ b/tests/http/routes/test_mantella_route.py
@@ -134,10 +134,6 @@ def test_setup_route_combinations(default_config: ConfigLoader, english_language
     # Create route instance
     route = mantella_route(
         config=default_config, 
-        stt_secret_key_file='STT_SECRET_KEY.txt', 
-        image_secret_key_file='IMAGE_SECRET_KEY.txt',
-        function_llm_secret_key_file='FUNCTION_GPT_SECRET_KEY.txt',
-        secret_key_file='GPT_SECRET_KEY.txt', 
         language_info=english_language_info, 
         show_debug_messages=False
     )
@@ -153,10 +149,6 @@ def test_setup_route_ends_conversation(default_config: ConfigLoader, english_lan
     # Create route instance
     route = mantella_route(
         config=default_config, 
-        stt_secret_key_file='STT_SECRET_KEY.txt', 
-        image_secret_key_file='IMAGE_SECRET_KEY.txt',
-        function_llm_secret_key_file='FUNCTION_GPT_SECRET_KEY.txt',
-        secret_key_file='GPT_SECRET_KEY.txt', 
         language_info=english_language_info, 
         show_debug_messages=False
     )

--- a/tests/llm/test_function_client.py
+++ b/tests/llm/test_function_client.py
@@ -41,7 +41,7 @@ def test_function_client_initialization(default_config: ConfigLoader):
     Tests that FunctionClient initializes correctly with proper config values
     """    
     FunctionManager.load_all_actions()
-    client = FunctionClient(default_config, "GPT_SECRET_KEY.txt", "FUNCTION_SECRET_KEY.txt")
+    client = FunctionClient(default_config)
     
     assert client is not None
 
@@ -58,7 +58,7 @@ def test_function_client_uses_separate_config(default_config: ConfigLoader):
     default_config.function_llm_params = {"temperature": 0.3}
     
     FunctionManager.load_all_actions()
-    client = FunctionClient(default_config, "GPT_SECRET_KEY.txt", "FUNCTION_SECRET_KEY.txt")
+    client = FunctionClient(default_config)
     
     # Verify function client uses function-specific config
     assert client.model_name == default_config.function_llm

--- a/tests/llm/test_image_client.py
+++ b/tests/llm/test_image_client.py
@@ -33,14 +33,14 @@ def image_client_default_llm(default_config: ConfigLoader):
     """Provides an ImageClient instance using the main LLM config for vision"""
     default_config.custom_vision_model = False
     default_config.vision_enabled = True
-    return ImageClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    return ImageClient(default_config)
 
 @pytest.fixture
 def image_client_custom_llm(default_config: ConfigLoader):
     """Provides an ImageClient instance using a separate vision LLM config"""
     default_config.custom_vision_model = True
     default_config.vision_enabled = True
-    return ImageClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    return ImageClient(default_config)
 
 @pytest.fixture
 def sample_openai_messages() -> list:

--- a/tests/llm/test_llm_client.py
+++ b/tests/llm/test_llm_client.py
@@ -20,7 +20,7 @@ def example_system_message(default_config: ConfigLoader):
 def llm_client_w_function_client(default_config: ConfigLoader):
     default_config.advanced_actions_enabled = True
     default_config.custom_function_model = True
-    client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt", "FUNCTION_SECRET_KEY.txt")
+    client = LLMClient(default_config)
     return client
 
 
@@ -36,40 +36,40 @@ def test_missing_api_key_uses_fallback(default_config: ConfigLoader, tmp_path, m
     # When API key file is empty/missing, client should still be created with fallback
     # For cloud APIs, the fallback is 'abc123'
     default_config.llm_api = 'OpenRouter' # Cloud API
-    client = LLMClient(default_config, "", "IMAGE_SECRET_KEY.txt")
+    client = LLMClient(default_config)
     assert client.api_key == 'abc123'
 
 
 def test_apis_load_correctly(default_config: ConfigLoader):
     default_config.llm_api = 'OpenRouter'
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._base_url == 'https://openrouter.ai/api/v1'
     assert llm_client.is_local is False
 
     default_config.llm_api = 'OpenAI'
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._base_url == 'https://api.openai.com/v1'
     assert llm_client.is_local is False
 
     default_config.llm_api = 'KoboldCpp'
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._base_url == 'http://127.0.0.1:5001/v1'
     assert llm_client.is_local is True
 
     default_config.llm_api = 'textgenwebui'
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._base_url == 'http://127.0.0.1:5000/v1'
     assert llm_client.is_local is True
 
     # Custom external URL
     default_config.llm_api = 'https://custom-url.com'
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._base_url == 'https://custom-url.com'
     assert llm_client.is_local is False
 
     # Custom local URL
     default_config.llm_api = 'http://custom-url.com'
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._base_url == 'http://custom-url.com'
     assert llm_client.is_local is True
     assert llm_client.api_key == 'abc123'
@@ -82,12 +82,12 @@ def test_startup_async_client_initialized(llm_client: LLMClient):
 
 def test_default_vision_model_loads_correctly(default_config: ConfigLoader):
     default_config.vision_enabled = True
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._image_client is not None
 
 
 def test_vision_model_disabled(default_config: ConfigLoader):
-    llm_client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    llm_client = LLMClient(default_config)
     assert llm_client._image_client is None
 
 
@@ -226,7 +226,7 @@ def test_function_client_created_when_enabled(default_config: ConfigLoader):
     FunctionManager.load_all_actions()
     default_config.advanced_actions_enabled = True
     default_config.custom_function_model = True
-    client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt", "FUNCTION_SECRET_KEY.txt")
+    client = LLMClient(default_config)
     
     # Check that the function client exists
     assert hasattr(client, '_function_client')
@@ -238,7 +238,7 @@ def test_no_function_client_by_default(default_config: ConfigLoader):
     """
     Tests that LLMClient does not create a FunctionClient when flags are disabled
     """
-    client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt", "FUNCTION_SECRET_KEY.txt")
+    client = LLMClient(default_config)
 
     assert hasattr(client, '_function_client')
     assert client._function_client is None
@@ -251,7 +251,7 @@ def test_no_function_client_when_only_advanced_enabled(default_config: ConfigLoa
     default_config.advanced_actions_enabled = True
     default_config.custom_function_model = False
     
-    client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt")
+    client = LLMClient(default_config)
     
     assert client._function_client is None
 
@@ -263,7 +263,7 @@ def test_llm_client_no_function_client_when_only_custom_model_enabled(default_co
     default_config.advanced_actions_enabled = False
     default_config.custom_function_model = True
     
-    client = LLMClient(default_config, "GPT_SECRET_KEY.txt", "IMAGE_SECRET_KEY.txt", "FUNCTION_SECRET_KEY.txt")
+    client = LLMClient(default_config)
     
     assert client._function_client is None
 


### PR DESCRIPTION
# Summary

Replaces the old per-component key file plumbing (eg `STT_SECRET_KEY.txt`) with a centralised API key resolver in `ClientBase`. API keys are now looked up by service name (eg `"OpenRouter"`, `"OpenAI"`) from a single `secret_keys.json` file that can be configured by advanced users, with `GPT_SECRET_KEY.txt` still kept as the default to keep initial setup simple.

# Details

## Key Lookup (`_get_api_key`)

When any component needs an API key, it calls `ClientBase._get_api_key(service)`. The lookup order is:

1. `secret_keys.json` in the Mantella mod folder (when running via the packaged mod)
2. `secret_keys.json` next to the executable (when running via `main.py`)
3. `GPT_SECRET_KEY.txt` in the mod folder
4. `GPT_SECRET_KEY.txt` next to the executable

## Service Resolution (`_get_endpoint`)

A single map `_KNOWN_SERVICES` maps every recognised service name / alias / shorthand to its endpoint URL. For example, all of these are equivalent and resolve to the same OpenRouter endpoint:
- `"OpenRouter"`, `"openrouter"`, `"or"`

## Example `secret_keys.json`

```json
{
    "OpenRouter": "sk-or-...",
    "OpenAI": "sk-..."
}
```