### PR TITLE
Toggle actions via Mantella UI

### DIFF
--- a/data/actions/absolve_crime.json
+++ b/data/actions/absolve_crime.json
@@ -4,7 +4,6 @@
     "description": "Absolve a non-violent crime the player has been accused of.",
     "note": "This action will fail if a guard is not in the conversation, and the NPC will be informed as such. If the AddToConversation action is enabled, these actions can synergise to allow NPCs to call over a nearby guard to absolve the crime.",
     "key": "AbsolveCrime",
-    "enabled": false,
     "parameters": {
         "crime_gold": {
             "type": "integer",

--- a/data/actions/add_to_conversation.json
+++ b/data/actions/add_to_conversation.json
@@ -3,7 +3,6 @@
     "name": "AddToConversation",
     "description": "Add nearby NPC(s) to the conversation.",
     "key": "AddToConversation",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/attack.json
+++ b/data/actions/attack.json
@@ -3,7 +3,6 @@
     "name": "Attack",
     "description": "Make NPC(s) attack another NPC / the player.",
     "key": "Attack",
-    "enabled": true,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/barter.json
+++ b/data/actions/barter.json
@@ -3,7 +3,6 @@
     "name": "Barter",
     "description": "Show what an NPC has for sale.",
     "key": "Barter",
-    "enabled": true,
     "parameters": {
         "source": {
             "type": "string",

--- a/data/actions/brawl.json
+++ b/data/actions/brawl.json
@@ -4,7 +4,6 @@
     "description": "Make NPC(s) non-lethally brawl the player.",
     "note": "EXPERIMENTAL: Can cause NPC AI packages to break.",
     "key": "Brawl",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/cancel_travel.json
+++ b/data/actions/cancel_travel.json
@@ -4,7 +4,6 @@
     "description": "Cancels NPC travel plans set by the TravelTo action.",
     "note": "EXPERIMENTAL: Can cause NPC AI packages to break.",
     "key": "CancelTravel",
-    "enabled": false,
     "allowed_games": ["skyrim"],
     "requires_response": false,
     "is-interrupting": false,

--- a/data/actions/cast_spell.json
+++ b/data/actions/cast_spell.json
@@ -3,7 +3,6 @@
     "name": "CastSpell",
     "description": "Make NPC cast a spell on another NPC / themselves. Only one spell can be cast per turn.",
     "key": "CastSpell",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "string",

--- a/data/actions/check_directions.json
+++ b/data/actions/check_directions.json
@@ -4,7 +4,6 @@
     "description": "Returns directions on how to reach a specified location.",
     "note": "NPCs can sometimes choose incompatible locations to check directions to. Known locations are an exhaustive list of game locations that have a map marker.",
     "key": "CheckDirections",
-    "enabled": false,
     "parameters": {
         "location": {
             "type": "string",

--- a/data/actions/collect_ingredients.json
+++ b/data/actions/collect_ingredients.json
@@ -3,7 +3,6 @@
     "name": "CollectIngredients",
     "description": "Make NPC(s) collect ingredients in the area.",
     "key": "CollectIngredients",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/emote.json
+++ b/data/actions/emote.json
@@ -4,7 +4,6 @@
     "description": "Make NPC(s) perform an emote animation.",
     "note": "Individual emotes can be enabled/disabled in data/Skyrim/skyrim_idles.csv.",
     "key": "Emote",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/end_conversation.json
+++ b/data/actions/end_conversation.json
@@ -4,7 +4,6 @@
     "description": "End the current conversation.",
     "note": "By default, this action is only enabled for radiant conversations. See the 'one-on-one', 'multi-npc', and 'radiant' toggles below.",
     "key": "EndConversation",
-    "enabled": true,
     "prompt": "When the conversation naturally concludes, begin your response with '{key}:'",
     "allowed_games": ["skyrim", "fallout4"],
     "requires_response": false,

--- a/data/actions/flee.json
+++ b/data/actions/flee.json
@@ -3,7 +3,6 @@
     "name": "Flee",
     "description": "Make NPC(s) flee from a specific NPC / the player.",
     "key": "Flee",
-    "enabled": true,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/follow.json
+++ b/data/actions/follow.json
@@ -4,7 +4,6 @@
     "description": "Make NPC(s) follow the player.",
     "note": "EXPERIMENTAL: May cause NPC AI packages to break.",
     "key": "Follow",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/inventory.json
+++ b/data/actions/inventory.json
@@ -3,7 +3,6 @@
     "name": "Inventory",
     "description": "Open inventory to give / take items with the player.",
     "key": "Inventory",
-    "enabled": true,
     "parameters": {
         "source": {
             "type": "string",

--- a/data/actions/lead_to.json
+++ b/data/actions/lead_to.json
@@ -4,7 +4,6 @@
     "description": "Make NPC lead another NPC (or the player) to a specific location.",
     "note": "EXPERIMENTAL: Can cause NPC AI packages to break. NPCs can sometimes choose incompatible locations to lead to. Known locations are an exhaustive list of game locations that have a map marker.",
     "key": "LeadTo",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "string",

--- a/data/actions/listen.json
+++ b/data/actions/listen.json
@@ -4,7 +4,6 @@
     "description": "Listen carefully to what the player has to say, allowing them extra time to speak.",
     "note": "For mic users. By default, this action cannot be triggered by NPCs (see the 'one-on-one', 'multi-npc', and 'radiant' toggles below to change this). Instead, it can be triggered by simply saying the keyword 'listen' into the mic.",
     "key": "Listen",
-    "enabled": true,
     "prompt": "To listen attentively to the player, allowing them more time to formulate their response, begin your response with '{key}:'.",
     "pause_seconds": 10.0,
     "allowed_games": ["skyrim", "fallout4"],

--- a/data/actions/look.json
+++ b/data/actions/look.json
@@ -4,7 +4,6 @@
     "description": "Look at what the player sees.",
     "note": "Vision must also be enabled in the Mantella UI for this action to work. If enabled, NPCs can choose whether to use vision each turn. If disabled, vision will trigger every turn.",
     "key": "Look",
-    "enabled": false,
     "prompt": "To see what the player sees, begin your response with '{key}:'.",
     "allowed_games": ["skyrim"],
     "requires_response": false,

--- a/data/actions/loot.json
+++ b/data/actions/loot.json
@@ -3,7 +3,6 @@
     "name": "Loot",
     "description": "Make NPC(s) loot items in the area.",
     "key": "Loot",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/move_to.json
+++ b/data/actions/move_to.json
@@ -3,7 +3,6 @@
     "name": "MoveTo",
     "description": "Make NPC(s) move to a specific NPC.",
     "key": "MoveTo",
-    "enabled": true,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/report_crime.json
+++ b/data/actions/report_crime.json
@@ -4,7 +4,6 @@
     "description": "Report a crime the player has committed.",
     "note": "This action will fail if a guard is not in the conversation, and the NPC will be informed as such (otherwise it would be chaos). If the AddToConversation action is enabled, these actions can synergise to allow NPCs to call over a nearby guard to report to.",
     "key": "ReportCrime",
-    "enabled": false,
     "parameters": {
         "crime_gold": {
             "type": "integer",

--- a/data/actions/share_conversation.json
+++ b/data/actions/share_conversation.json
@@ -3,7 +3,6 @@
     "name": "ShareConversation",
     "description": "Share this conversation with an NPC who is not present once the conversation ends. They will remember what was discussed.",
     "key": "ShareConversation",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "string",

--- a/data/actions/stand_down.json
+++ b/data/actions/stand_down.json
@@ -3,7 +3,6 @@
     "name": "StandDown",
     "description": "Make an NPC(s) stop attacking the player / another NPC.",
     "key": "StandDown",
-    "enabled": true,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/teleport.json
+++ b/data/actions/teleport.json
@@ -3,7 +3,6 @@
     "name": "Teleport",
     "description": "Make NPC(s) teleport to a specific NPC. Use this action when an NPC is stuck or needs to quickly change location.",
     "key": "Teleport",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/travel_to.json
+++ b/data/actions/travel_to.json
@@ -4,7 +4,6 @@
     "description": "Make NPC(s) travel to a specific location.",
     "note": "EXPERIMENTAL: Can cause NPC AI packages to break. NPCs can sometimes choose incompatible locations to travel to. Known locations are an exhaustive list of game locations that have a map marker.",
     "key": "TravelTo",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/unfollow.json
+++ b/data/actions/unfollow.json
@@ -3,7 +3,6 @@
     "name": "Unfollow",
     "description": "Make NPC(s) stop following the player.",
     "key": "Unfollow",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/data/actions/wait.json
+++ b/data/actions/wait.json
@@ -3,7 +3,6 @@
     "name": "Wait",
     "description": "Make NPC(s) wait / rest in the area.",
     "key": "Wait",
-    "enabled": false,
     "parameters": {
         "source": {
             "type": "array",

--- a/src/actions/function_manager.py
+++ b/src/actions/function_manager.py
@@ -151,11 +151,11 @@ class FunctionManager:
 
 
     @staticmethod
-    def load_all_actions(include_disabled: bool = False) -> None:
+    def load_all_actions(disabled_actions: list[str] | None = None) -> None:
         """Load all actions from the data/actions/ folder at server startup
 
         Args:
-            include_disabled: If True, load actions even if they have enabled=false.
+            disabled_actions: List of action names to disable. If None, all actions are loaded.
         """
         # Get the project root directory (two levels up from this file)
         actions_dir = Path(utils.resolve_path()) / "data" / "actions"
@@ -168,10 +168,12 @@ class FunctionManager:
         FunctionManager._last_tool_calls = []
         FunctionManager._disabled_action_names = []
 
+        disabled_set = set(n.lower() for n in disabled_actions) if disabled_actions is not None else set()
+
         # Load top-level action files
         for file_path in actions_dir.glob("*.json"):
             try:
-                FunctionManager._load_action_file(file_path, include_disabled)
+                FunctionManager._load_action_file(file_path, disabled_set)
             except Exception as e:
                 logger.warning(f"Failed to load action file {file_path}: {e}")
 
@@ -245,8 +247,12 @@ class FunctionManager:
 
 
     @staticmethod
-    def _load_action_file(file_path: Path, include_disabled: bool = False) -> None:
-        """Load a single action file"""
+    def _load_action_file(file_path: Path, disabled_set: set[str] | None = None) -> None:
+        """Load a single action file
+
+        Args:
+            disabled_set: Set of lowercased action names to skip to check current action against.
+        """
         with open(file_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
 
@@ -254,9 +260,14 @@ class FunctionManager:
         actions_data = data if isinstance(data, list) else [data]
 
         for action_data in actions_data:
-            # Skip disabled actions (default to enabled if not specified)
-            if not include_disabled and not action_data.get('enabled', True):
-                FunctionManager._disabled_action_names.append(action_data.get('name', 'Unknown'))
+            name = action_data.get('name')
+            if not name:
+                logger.warning(f"Action in '{file_path.name}' is missing a 'name' field, skipping")
+                continue
+
+            # Skip actions whose name is in the disabled set
+            if disabled_set is not None and name.lower() in disabled_set:
+                FunctionManager._disabled_action_names.append(name)
                 continue
             
             # Ensure identifier starts with 'mantella_'

--- a/src/config/config_loader.py
+++ b/src/config/config_loader.py
@@ -392,6 +392,7 @@ LLM parameter list must be valid JSON""")
             
             # Actions
             self.advanced_actions_enabled = self.__definitions.get_bool_value("advanced_actions_enabled")
+            self.disabled_actions: list[str] = self.__definitions.get_string_list_value("disabled_actions")
             self.custom_function_model = self.__definitions.get_bool_value("custom_function_model")
             self.function_llm_api = self.__definitions.get_string_value("function_llm_api")
             self.function_llm = self.__definitions.get_string_value("function_llm")

--- a/src/config/definitions/action_definitions.py
+++ b/src/config/definitions/action_definitions.py
@@ -1,8 +1,35 @@
+import json
+from pathlib import Path
 from src.config.types.config_value import ConfigValue, ConfigValueTag
 from src.config.types.config_value_bool import ConfigValueBool
 from src.config.types.config_value_int import ConfigValueInt
+from src.config.types.config_value_multi_selection import ConfigValueMultiSelection
 from src.config.types.config_value_selection import ConfigValueSelection
 from src.config.types.config_value_string import ConfigValueString
+from src import utils
+
+
+def _scan_action_names() -> list[str]:
+    """Scan action JSON files and return a lightweight sorted list of action names.
+    """
+    actions_dir = Path(utils.resolve_path()) / "data" / "actions"
+    if not actions_dir.exists():
+        return []
+
+    names = []
+    for file_path in actions_dir.glob("*.json"):
+        try:
+            with open(file_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            actions_data = data if isinstance(data, list) else [data]
+            for action_data in actions_data:
+                name = action_data.get('name')
+                if name:
+                    names.append(name)
+        except Exception:
+            continue
+    return sorted(names)
+
 
 class ActionDefinitions:
     @staticmethod
@@ -11,6 +38,37 @@ class ActionDefinitions:
                         If disabled, only basic actions can be triggered by the LLM using an '[action_name]: [NPC response]' format (eg 'Follow: Lead the way').
                         Actions without a 'prompt' field defined in the action's JSON file (see data/actions/) can only be triggered when this setting is enabled."""
         return ConfigValueBool("advanced_actions_enabled", "Advanced Actions", description, False)
+    
+    @staticmethod
+    def get_disabled_actions_config_value() -> ConfigValue:
+        action_names = _scan_action_names()
+        description = """Actions not selected here will be available in conversations.
+                        Some actions can only be triggered when `Advanced Actions` is enabled above.
+                        To learn more about an action, see the associated JSON file in the data/actions/ folder."""
+        default_disabled = [
+            "AbsolveCrime",
+            "AddToConversation",
+            "Brawl",
+            "CancelTravel",
+            "CastSpell",
+            "CheckDirections",
+            "CollectIngredients",
+            "Emote",
+            "Follow",
+            "LeadTo",
+            "Look",
+            "Loot",
+            "ReportCrime",
+            "ShareConversation",
+            "Teleport",
+            "TravelTo",
+            "Unfollow",
+            "Wait",
+        ]
+        # Only include defaults that actually exist in the scanned action names
+        valid_defaults = [name for name in default_disabled if name in action_names]
+        return ConfigValueMultiSelection("disabled_actions", "Disabled Actions", description, valid_defaults, action_names)
+
 
     @staticmethod
     def get_custom_function_model_config_value() -> ConfigValue:

--- a/src/config/mantella_config_value_definitions_new.py
+++ b/src/config/mantella_config_value_definitions_new.py
@@ -137,6 +137,7 @@ class MantellaConfigValueDefinitionsNew:
 
         actions_category = ConfigValueGroup("Actions", "Actions", "Settings for in-game actions.", on_value_change_callback)
         actions_category.add_config_value(ActionDefinitions.get_advanced_actions_enabled_config_value())
+        actions_category.add_config_value(ActionDefinitions.get_disabled_actions_config_value())
         actions_category.add_config_value(ActionDefinitions.get_custom_function_model_config_value())
         actions_category.add_config_value(ActionDefinitions.get_function_llm_api_config_value())
         actions_category.add_config_value(ActionDefinitions.get_function_llm_model_config_value())

--- a/src/setup.py
+++ b/src/setup.py
@@ -23,7 +23,7 @@ class MantellaSetup:
         self.config = ConfigLoader(self.save_folder, config_file)    
         self._setup_logging(os.path.join(self.save_folder, logging_file), self.config.advanced_logs)
         
-        FunctionManager.load_all_actions()
+        FunctionManager.load_all_actions(disabled_actions=self.config.disabled_actions)
         FunctionManager.log_actions_enabled(self.config.advanced_actions_enabled)
         self.config.actions = FunctionManager.get_legacy_actions()
 

--- a/tests/actions/test_function_manager.py
+++ b/tests/actions/test_function_manager.py
@@ -12,7 +12,7 @@ def test_load_all_actions():
     FunctionManager._actions.clear()
     
     # Load actions
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Verify actions were loaded
     assert len(FunctionManager._actions) > 0
@@ -24,7 +24,7 @@ def test_load_all_actions():
 
 def test_load_all_actions_structure():
     """Test that loaded actions have required fields"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     for _, action in FunctionManager._actions.items():
         assert 'identifier' in action
@@ -38,46 +38,19 @@ def test_load_all_actions_structure():
         assert 'radiant' in action
 
 
-def test_load_all_actions_respects_enabled_flag(tmp_path):
-    """Test that actions with enabled: false are not loaded"""
+def test_load_all_actions_respects_disabled_list(tmp_path):
+    """Test that actions in the disabled list are not loaded"""
     FunctionManager._actions.clear()
-    
+    FunctionManager._disabled_action_names = []
+
     actions_dir = tmp_path / "actions"
     actions_dir.mkdir()
     
-    enabled_action = {
-        "identifier": "test_enabled",
-        "name": "EnabledAction",
+    action_a = {
+        "identifier": "test_a",
+        "name": "ActionA",
         "description": "Test",
-        "key": "Enabled",
-        "prompt": "Test",
-        "enabled": True,
-        "requires_response": False,
-        "is-interrupting": False,
-        "one-on-one": True,
-        "multi-npc": False,
-        "radiant": False
-    }
-    
-    disabled_action = {
-        "identifier": "test_disabled",
-        "name": "DisabledAction",
-        "description": "Test",
-        "key": "Disabled",
-        "prompt": "Test",
-        "enabled": False,
-        "requires_response": False,
-        "is-interrupting": False,
-        "one-on-one": True,
-        "multi-npc": False,
-        "radiant": False
-    }
-    
-    default_action = {
-        "identifier": "test_default",
-        "name": "DefaultAction",
-        "description": "Test",
-        "key": "Default",
+        "key": "A",
         "prompt": "Test",
         "requires_response": False,
         "is-interrupting": False,
@@ -85,31 +58,56 @@ def test_load_all_actions_respects_enabled_flag(tmp_path):
         "multi-npc": False,
         "radiant": False
     }
-    
-    with open(actions_dir / "enabled.json", 'w') as f:
-        json.dump(enabled_action, f)
-    with open(actions_dir / "disabled.json", 'w') as f:
-        json.dump(disabled_action, f)
-    with open(actions_dir / "default.json", 'w') as f:
-        json.dump(default_action, f)
-    
-    # Load test actions
+
+    action_b = {
+        "identifier": "test_b",
+        "name": "ActionB",
+        "description": "Test",
+        "key": "B",
+        "prompt": "Test",
+        "requires_response": False,
+        "is-interrupting": False,
+        "one-on-one": True,
+        "multi-npc": False,
+        "radiant": False
+    }
+
+    action_c = {
+        "identifier": "test_c",
+        "name": "ActionC",
+        "description": "Test",
+        "key": "C",
+        "prompt": "Test",
+        "requires_response": False,
+        "is-interrupting": False,
+        "one-on-one": True,
+        "multi-npc": False,
+        "radiant": False
+    }
+
+    with open(actions_dir / "a.json", 'w') as f:
+        json.dump(action_a, f)
+    with open(actions_dir / "b.json", 'w') as f:
+        json.dump(action_b, f)
+    with open(actions_dir / "c.json", 'w') as f:
+        json.dump(action_c, f)
+
+    # Load with ActionB disabled
+    disabled_set = {"actionb"}
     for file_path in actions_dir.glob("*.json"):
-        FunctionManager._load_action_file(file_path)
-    
-    # Only enabled and default actions should be loaded
-    assert 'mantella_test_enabled' in FunctionManager._actions
-    assert 'mantella_test_default' in FunctionManager._actions
-    assert 'mantella_test_disabled' not in FunctionManager._actions
+        FunctionManager._load_action_file(file_path, disabled_set)
+
+    # ActionA and ActionC should be loaded, ActionB should not
+    assert 'mantella_test_a' in FunctionManager._actions
+    assert 'mantella_test_c' in FunctionManager._actions
+    assert 'mantella_test_b' not in FunctionManager._actions
     assert len(FunctionManager._actions) == 2
-    
-    # Cleanup: Restore original actions
-    FunctionManager.load_all_actions(include_disabled=True)
+    assert 'ActionB' in FunctionManager._disabled_action_names
 
 
 def test_get_legacy_actions():
     """Test that get_legacy_actions returns Action objects"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     legacy_actions = FunctionManager.get_legacy_actions()
     
@@ -143,7 +141,7 @@ def test_parse_function_calls_none():
 def test_parse_function_calls_valid():
     """Test parsing valid function calls"""
     # Load actions first to have action mappings
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Create a mock tool call
     tool_calls = [
@@ -166,7 +164,7 @@ def test_parse_function_calls_valid():
 def test_parse_function_calls_malformed_json():
     """Test parsing function calls with malformed JSON arguments"""
     # Load actions first to have action mappings
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
 
     tool_calls = [
         {
@@ -186,7 +184,7 @@ def test_parse_function_calls_malformed_json():
 
 def test_parse_function_calls_unknown_function():
     """Test parsing function calls with unknown function name"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -205,7 +203,7 @@ def test_parse_function_calls_unknown_function():
 
 def test_parse_function_calls_multiple_calls():
     """Test parsing multiple function calls"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -231,7 +229,7 @@ def test_parse_function_calls_multiple_calls():
 
 def test_generate_context_aware_tools(default_context: Context):
     """Test generating context-aware tools from loaded actions"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tools = FunctionManager.generate_context_aware_tools(default_context)
     
@@ -249,7 +247,7 @@ def test_generate_context_aware_tools(default_context: Context):
 
 def test_generate_context_aware_tools_adds_npc_context(default_context: Context):
     """Test that NPC context is added to tool parameters"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tools = FunctionManager.generate_context_aware_tools(default_context)
     
@@ -272,7 +270,7 @@ def test_generate_context_aware_tools_adds_npc_context(default_context: Context)
 
 def test_parse_function_calls_exception_handling():
     """Test that exceptions during parsing are handled gracefully"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
 
     # Create a tool call that might cause issues
     tool_calls = [
@@ -297,7 +295,7 @@ def test_parse_function_calls_exception_handling():
 
 def test_generate_context_aware_tools_with_parameters(default_context: Context):
     """Test that tools with parameters are properly formatted"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tools = FunctionManager.generate_context_aware_tools(default_context)
     
@@ -436,7 +434,7 @@ def test_validate_npc_names_duplicate_names(example_characters_pc_to_npc: Charac
 
 def test_parse_function_calls_with_validation_valid_source(example_characters_pc_to_npc: Characters):
     """Test parsing with valid source parameter"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -455,7 +453,7 @@ def test_parse_function_calls_with_validation_valid_source(example_characters_pc
 
 def test_parse_function_calls_with_validation_invalid_source(example_characters_pc_to_npc: Characters):
     """Test parsing with invalid source parameter - action should be skipped"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -474,7 +472,7 @@ def test_parse_function_calls_with_validation_invalid_source(example_characters_
 
 def test_parse_function_calls_with_validation_mixed_valid_invalid_source(example_characters_pc_to_npc: Characters):
     """Test parsing with mix of valid and invalid source names"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -494,7 +492,7 @@ def test_parse_function_calls_with_validation_mixed_valid_invalid_source(example
 
 def test_parse_function_calls_with_validation_valid_target(example_characters_pc_to_npc: Characters):
     """Test parsing with valid target parameter"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Manually add a test action with source and target parameters
     FunctionManager._actions['test_action'] = {
@@ -524,7 +522,7 @@ def test_parse_function_calls_with_validation_valid_target(example_characters_pc
 
 def test_parse_function_calls_with_validation_target_includes_player(example_characters_pc_to_npc: Characters):
     """Test that target can include player (exclude_player=False for target)"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Manually add a test action with source and target parameters
     FunctionManager._actions['test_action'] = {
@@ -553,7 +551,7 @@ def test_parse_function_calls_with_validation_target_includes_player(example_cha
 
 def test_parse_function_calls_with_validation_source_excludes_player(example_characters_pc_to_npc: Characters):
     """Test that source excludes player (exclude_player=True for source)"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -574,7 +572,7 @@ def test_parse_function_calls_with_validation_source_excludes_player(example_cha
 
 def test_parse_function_calls_with_validation_other_params_unchanged(example_characters_pc_to_npc: Characters):
     """Test that non-NPC parameters are passed through unchanged"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Add a test action with multiple parameter types
     FunctionManager._actions['test_action'] = {
@@ -613,7 +611,7 @@ def test_parse_function_calls_with_validation_other_params_unchanged(example_cha
 
 def test_parse_function_calls_case_insensitive_validation(example_characters_pc_to_npc: Characters):
     """Test that NPC validation is case-insensitive and preserves LLM casing"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -634,7 +632,7 @@ def test_parse_function_calls_case_insensitive_validation(example_characters_pc_
 
 def test_parse_function_calls_skip_action_when_all_sources_invalid(example_characters_pc_to_npc: Characters):
     """Test that action is skipped when all source NPCs are invalid"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -660,7 +658,7 @@ def test_parse_function_calls_skip_action_when_all_sources_invalid(example_chara
 
 def test_validate_arguments_against_schema_valid_args():
     """Test that valid arguments pass through unchanged"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Follow action has 'source' parameter
     defined_params = {'source': {'type': 'array'}}
@@ -675,7 +673,7 @@ def test_validate_arguments_against_schema_valid_args():
 
 def test_validate_arguments_against_schema_hallucinated_args():
     """Test that hallucinated / unknown arguments are filtered out"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Follow action has 'source' parameter
     defined_params = {'source': {'type': 'array'}}
@@ -699,7 +697,7 @@ def test_validate_arguments_against_schema_hallucinated_args():
 
 def test_validate_arguments_against_schema_all_invalid():
     """Test when all arguments are invalid/hallucinated"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     defined_params = {'source': {'type': 'array'}}
     
@@ -719,7 +717,7 @@ def test_validate_arguments_against_schema_all_invalid():
 
 def test_validate_arguments_against_schema_mixed_valid_invalid():
     """Test with mix of valid and invalid parameters"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Action with multiple parameters
     defined_params = {
@@ -752,7 +750,7 @@ def test_validate_arguments_against_schema_mixed_valid_invalid():
 
 def test_validate_arguments_against_schema_empty_params():
     """Test validation when action has no parameters defined"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     defined_params = {}
     llm_arguments = {'some_arg': 'value'}
@@ -767,7 +765,7 @@ def test_validate_arguments_against_schema_empty_params():
 
 def test_parse_function_calls_with_hallucinated_args(example_characters_pc_to_npc: Characters):
     """Test that hallucinated arguments are filtered during parsing"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     tool_calls = [
         {
@@ -793,7 +791,7 @@ def test_parse_function_calls_with_hallucinated_args(example_characters_pc_to_np
 
 def test_parse_function_calls_validation_order():
     """Test that schema validation happens before NPC name validation"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # No characters manager provided, so only schema validation should occur
     tool_calls = [
@@ -819,7 +817,7 @@ def test_parse_function_calls_validation_order():
 
 def test_parse_function_calls_empty_arguments_not_included():
     """Test that when all arguments are filtered out, 'arguments' key is not present"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Offended action has no parameters defined in JSON
     tool_calls = [
@@ -841,7 +839,7 @@ def test_parse_function_calls_empty_arguments_not_included():
 
 def test_parse_function_calls_hallucinated_args_removed_completely():
     """Test that when all LLM arguments are hallucinated and filtered, 'arguments' key is not present"""
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     
     # Offended action has no parameters, LLM hallucinates some
     tool_calls = [
@@ -986,7 +984,7 @@ class TestParseWithNearbyNPCs:
 
     def test_parse_with_nearby_target_validation(self, example_characters_with_nearby: Characters):
         """Should validate target parameter against nearby NPCs"""
-        FunctionManager.load_all_actions(include_disabled=True)
+        FunctionManager.load_all_actions()
         
         # Attack action: source=conversation, target=all_npcs_w_player
         tool_calls = [
@@ -1010,7 +1008,7 @@ class TestParseWithNearbyNPCs:
 
     def test_parse_with_invalid_nearby_target(self, example_characters_with_nearby: Characters):
         """Should skip action when required parameter is invalid"""
-        FunctionManager.load_all_actions(include_disabled=True)
+        FunctionManager.load_all_actions()
         
         tool_calls = [
             {
@@ -1031,7 +1029,7 @@ class TestParseWithNearbyNPCs:
 
     def test_parse_follow_with_multiple_conversation_npcs(self, example_characters_multi_npc: Characters):
         """Should validate multiple source NPCs from conversation"""
-        FunctionManager.load_all_actions(include_disabled=True)
+        FunctionManager.load_all_actions()
         
         tool_calls = [
             {
@@ -1052,7 +1050,7 @@ class TestParseWithNearbyNPCs:
 
     def test_parse_mixed_valid_invalid_sources(self, example_characters_pc_to_npc):
         """Should filter out invalid NPCs but keep valid ones"""
-        FunctionManager.load_all_actions(include_disabled=True)
+        FunctionManager.load_all_actions()
         
         tool_calls = [
             {
@@ -1077,7 +1075,7 @@ class TestToolGenerationWithNearby:
 
     def test_adds_nearby_npcs_to_target_parameter(self, example_context_with_nearby: Context):
         """Should add nearby NPCs to target parameter description"""
-        FunctionManager.load_all_actions(include_disabled=True)
+        FunctionManager.load_all_actions()
         
         tools = FunctionManager.generate_context_aware_tools(example_context_with_nearby)
         
@@ -1097,7 +1095,7 @@ class TestToolGenerationWithNearby:
 
     def test_conversation_scope_excludes_nearby(self, example_context_with_nearby: Context):
         """Should not include nearby NPCs in conversation-scoped parameters"""
-        FunctionManager.load_all_actions(include_disabled=True)
+        FunctionManager.load_all_actions()
         
         tools = FunctionManager.generate_context_aware_tools(example_context_with_nearby)
         
@@ -1117,7 +1115,7 @@ class TestToolGenerationWithNearby:
 
     def test_no_nearby_npcs_graceful_handling(self, default_context):
         """Should work normally when no nearby NPCs are set"""
-        FunctionManager.load_all_actions(include_disabled=True)
+        FunctionManager.load_all_actions()
         
         # Don't set nearby NPCs (default empty)
         tools = FunctionManager.generate_context_aware_tools(default_context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def default_config(tmp_path: Path) -> ConfigLoader:
     default_config = ConfigLoader(mygame_folder_path=str(tmp_path), game_override=GameEnum.SKYRIM)
 
     # Load actions (simulating what setup.py does after logging is configured)
-    FunctionManager.load_all_actions(include_disabled=True)
+    FunctionManager.load_all_actions()
     default_config.actions = FunctionManager.get_legacy_actions()
 
     # Load the actual config file
@@ -138,7 +138,7 @@ def llm_client(default_config: ConfigLoader) -> LLMClient:
 @pytest.fixture
 def default_function_client(default_config: ConfigLoader) -> FunctionClient:
     """Provides a FunctionClient instance for testing"""
-    FunctionManager.load_all_actions(include_disabled=True) # This is called on server startup, but not when creating the client standalone
+    FunctionManager.load_all_actions() # This is called on server startup, but not when creating the client standalone
     return FunctionClient(default_config)
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Adds a "Disabled Actions" multi-select dropdown to the Actions config tab in the Mantella UI, replacing the need to edit individual action JSON files to enable/disable actions. If an action is not explictly disabled via this setting, it is enabled by default.

## Details

- Added a `ConfigValueMultiSelection` setting "Disabled Actions" to the Actions tab in the Mantella UI.
- `FunctionManager.load_all_actions()` now accepts a `disabled_actions` list (from the config) and uses it to filter actions by name. The per-JSON `enabled` field has been removed from all action files.
- The config setting is the single source of truth for whether an action is enabled.