### PR TITLE
Add dedicated LLM support for conversation summaries

### DIFF
--- a/src/config/definitions/llm_definitions.py
+++ b/src/config/definitions/llm_definitions.py
@@ -169,7 +169,7 @@ class LLMDefinitions:
         description = """Enable a separate LLM client for generating conversation summaries.
             When enabled, the Summary LLM settings below will be used instead of the main LLM settings.
             When disabled, summaries use the same LLM as conversations."""
-        return ConfigValueBool("summary_llm_enabled", "Custom Summary Model", description, False, tags=[ConfigValueTag.advanced])
+        return ConfigValueBool("summary_llm_enabled", "Enable Dedicated Summary LLM", description, False, tags=[ConfigValueTag.advanced])
 
     @staticmethod
     def get_summary_llm_api_config_value() -> ConfigValue:
@@ -181,7 +181,7 @@ class LLMDefinitions:
             If you are using an API (OpenAI, OpenRouter, etc) ensure you have the correct secret key set in `GPT_SECRET_KEY.txt` for the respective service you are using.
 
             By default, summaries use the same LLM as conversations. Configure this to use a different model for summaries."""
-        return ConfigValueSelection("summary_llm_api","Custom Summary Model Service",description,"OpenRouter",["OpenRouter", "OpenAI", "NanoGPT", "KoboldCpp", "textgenwebui"],allows_free_edit=True,tags=[ConfigValueTag.advanced])
+        return ConfigValueSelection("summary_llm_api","Summary LLM API / Endpoint",description,"OpenRouter",["OpenRouter", "OpenAI", "NanoGPT", "KoboldCpp", "textgenwebui"],allows_free_edit=True,tags=[ConfigValueTag.advanced])
 
     @staticmethod
     def get_summary_llm_config_value() -> ConfigValue:
@@ -190,14 +190,14 @@ class LLMDefinitions:
                             The list does not provide all details about the models. For additional information please refer to the corresponding sites:
                             - OpenRouter: https://openrouter.ai/docs#models
                             - OpenAI: https://platform.openai.com/docs/models https://openai.com/api/pricing/"""
-        return ConfigValueSelection("summary_llm","Custom Summary Model",model_description,"google/gemma-4-26b-a4b-it:free",["Custom Model"],allows_values_not_in_options=True,tags=[ConfigValueTag.advanced])
+        return ConfigValueSelection("summary_llm","Summary LLM Model",model_description,"google/gemma-4-26b-a4b-it:free",["Custom Model"],allows_values_not_in_options=True,tags=[ConfigValueTag.advanced])
 
     @staticmethod
     def get_summary_custom_token_count_config_value() -> ConfigValue:
         description = """If the summary model chosen is not recognised by Mantella, the token count for the given model will default to this number.
                     If this is not the correct token count for your chosen model, you can change it here.
                     Keep in mind that if this number is greater than the actual token count of the model, then Mantella may crash if a given conversation exceeds the model's token limit."""
-        return ConfigValueInt("summary_custom_token_count","Custom Summary Model Token Count",description,4096,4096,9999999,tags=[ConfigValueTag.advanced])
+        return ConfigValueInt("summary_custom_token_count","Summary Custom Token Count",description,4096,4096,9999999,tags=[ConfigValueTag.advanced])
 
     @staticmethod
     def get_summary_llm_params_config_value() -> ConfigValue:
@@ -207,4 +207,4 @@ class LLMDefinitions:
         value = """{
     "stop": ["#"]
 }"""
-        return ConfigValueString("summary_llm_params","Custom Summary Model Parameters",description,value,tags=[ConfigValueTag.advanced])
+        return ConfigValueString("summary_llm_params","Summary LLM Parameters",description,value,tags=[ConfigValueTag.advanced])

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -38,7 +38,7 @@ class GameStateManager:
         self.__game: Gameable = game
         self.__config: ConfigLoader = config
         self.__language_info: dict[Hashable, str] = language_info
-        self.__client: LLMClient = client
+        self.__dialogue_client: LLMClient = client
         self.__chat_manager: ChatManager = chat_manager
         self.__rememberer: Remembering = Summaries(game, config, client, language_info['language'], summary_client)
         self.__talk: Conversation | None = None
@@ -67,7 +67,7 @@ class GameStateManager:
         if input_json.__contains__(comm_consts.KEY_INPUTTYPE):
             self.process_stt_setup(input_json)
         
-        conversation_client = self._build_random_conversation_client() or self.__client
+        conversation_client = self._build_random_conversation_client() or self.__dialogue_client
         context_for_conversation = Context(world_id, self.__config, conversation_client, self.__rememberer, self.__language_info)
         self.__talk = Conversation(context_for_conversation, self.__chat_manager, self.__rememberer, conversation_client, self.__stt, self.__mic_input, self.__mic_ptt, self.__game)
         self.__update_context(input_json)
@@ -105,8 +105,8 @@ class GameStateManager:
             self.__config.claude_prompt_caching_enabled,
         )
         # Copy sub-clients from the main client so vision and tool-calling remain available
-        random_client._image_client = getattr(self.__client, '_image_client', None)
-        random_client._function_client = getattr(self.__client, '_function_client', None)
+        random_client._image_client = getattr(self.__dialogue_client, '_image_client', None)
+        random_client._function_client = getattr(self.__dialogue_client, '_function_client', None)
         random_client._vision_mode = random_client._determine_vision_mode()
         return random_client
         
@@ -201,7 +201,7 @@ class GameStateManager:
                 
                 if action.identifier == 'mantella_npc_vision':
                     # Enable vision for the next LLM call
-                    self.__client.enable_vision_for_next_call()
+                    self.__dialogue_client.enable_vision_for_next_call()
                     logger.log(23, "Vision action triggered via keyword: Vision enabled for next LLM call")
                     break # Don't send to game
                 

--- a/src/http/routes/mantella_route.py
+++ b/src/http/routes/mantella_route.py
@@ -51,14 +51,14 @@ class mantella_route(routeable):
 
         tts: TTSable = create_tts(self._config.tts_service, self._config, game)
 
-        llm_client = LLMClient(self._config)
+        dialogue_client = LLMClient(self._config)
 
         summary_client: SummaryLLMClient | None = None
         if self._config.summary_llm_enabled:
             summary_client = SummaryLLMClient(self._config)
 
-        chat_manager = ChatManager(self._config, tts, llm_client, game)
-        self.__game = GameStateManager(game, chat_manager, self._config, self.__language_info, llm_client, summary_client)
+        chat_manager = ChatManager(self._config, tts, dialogue_client, game)
+        self.__game = GameStateManager(game, chat_manager, self._config, self.__language_info, dialogue_client, summary_client)
 
     @utils.time_it
     def add_route_to_server(self, app: FastAPI):

--- a/src/llm/client_base.py
+++ b/src/llm/client_base.py
@@ -119,6 +119,11 @@ class ClientBase(AIClient):
         """The name of the model
         """
         return self._model_name
+
+    @property
+    def base_url(self) -> str:
+        """Resolved OpenAI-compatible endpoint used by this client."""
+        return self._base_url
     
     @property
     def is_local(self) -> bool:

--- a/src/llm/llm_client.py
+++ b/src/llm/llm_client.py
@@ -24,6 +24,8 @@ class LLMClient(ClientBase):
         )
         super().__init__(config.llm_api, config.llm, llm_params, config.custom_token_count, config.claude_prompt_caching_enabled)
 
+        logger.info(f"Dialogue LLM endpoint: {self.base_url}")
+
         if self._is_local:
             logger.info(f"Running Mantella with local language model")
         else:

--- a/src/llm/summary_client.py
+++ b/src/llm/summary_client.py
@@ -1,6 +1,9 @@
 from src.config.config_loader import ConfigLoader
 from src.llm.client_base import ClientBase
 from src.model_profile_manager import get_profile_manager
+from src import utils
+
+logger = utils.get_logger()
 
 class SummaryLLMClient(ClientBase):
     '''LLM client dedicated to generating conversation summaries.'''
@@ -14,3 +17,4 @@ class SummaryLLMClient(ClientBase):
             log_context="SummaryLLMClient",
         )
         super().__init__(config.summary_llm_api, config.summary_llm, summary_llm_params, config.summary_custom_token_count)
+        logger.info(f"Summary LLM endpoint: {self.base_url}")

--- a/src/remember/summaries.py
+++ b/src/remember/summaries.py
@@ -17,6 +17,14 @@ from src import utils
 
 logger = utils.get_logger()
 
+TRANSIENT_STATE_SUMMARY_RULE = (
+    "Do not record inventory contents, currently worn/equipped items, or whether an equip attempt "
+    "succeeded in long-term memory. Those facts are transient and are supplied authoritatively by "
+    "the game at runtime; dialogue claims about them are not evidence. Preserve relevant emotional "
+    "or narrative consequences, but treat historical equipment claims as past narrative only, "
+    "never as the NPC's current equipment."
+)
+
 
 class CharacterSummaryParameters:
     """Encapsulates the messages and involved characters for a single NPC's summary."""
@@ -29,16 +37,25 @@ class Summaries(Remembering):
     """ Stores a conversation as a summary in a text file.
         Loads the latest summary from disk for a prompt text.
     """
+    SUMMARY_MAX_ATTEMPTS = 3
+    SUMMARY_RETRY_DELAY_SECONDS = 1.0
+
     def __init__(self, game: Gameable, config: ConfigLoader, client: LLMClient, language_name: str, summary_client: SummaryLLMClient | None = None, summary_limit_pct: float = 0.3) -> None:
         super().__init__()
         self.loglevel = 28
         self.__config = config
         self.__game: Gameable = game
         self.__summary_limit_pct: float = summary_limit_pct
+        self.__dialogue_client: ClientBase = client
+        self.__summary_client: SummaryLLMClient | None = summary_client
         self.__client: ClientBase = summary_client if summary_client else client
         self.__language_name: str = language_name
         self.__memory_prompt: str = config.memory_prompt
         self.__resummarize_prompt: str = config.resummarize_prompt
+        if summary_client:
+            logger.info("Conversation summaries use the dedicated summary LLM")
+        else:
+            logger.info("Conversation summaries use the dialogue LLM (compatibility fallback)")
 
     def __read_summary_lines(self, file_path: str, deduplicate: bool = False) -> list[str]:
         """Read a summary file and return non-empty stripped lines.
@@ -298,22 +315,15 @@ class Summaries(Remembering):
                     races=races,
                     genders_and_races=genders_and_races
                 )
-        while True:
-            try:
-                if len(npc_info.messages) >= min_messages:
-                    summary = self.summarize_conversation(npc_info.messages.transform_to_dict_representation(npc_info.messages.get_talk_only()), prompt)
-                    # Prepend timestamp to summary if available
-                    if summary and end_timestamp is not None and self.__config.memory_prompt_datetime_prefix:
-                        timestamp_prefix = self.__format_timestamp(end_timestamp)
-                        summary = f"{timestamp_prefix}\n{summary}"
-                    return summary
-                else:
-                    logger.info(f"Conversation summary not saved. Not enough dialogue spoken.")
-                break
-            except Exception:
-                logger.error('Failed to summarize conversation. Retrying...')
-                time.sleep(5)
-                continue
+        prompt = f"{prompt.rstrip()}\n\n{TRANSIENT_STATE_SUMMARY_RULE}"
+        if len(npc_info.messages) >= min_messages:
+            summary = self.summarize_conversation(npc_info.messages.transform_to_dict_representation(npc_info.messages.get_talk_only()), prompt)
+            # Prepend timestamp to summary if available
+            if summary and end_timestamp is not None and self.__config.memory_prompt_datetime_prefix:
+                timestamp_prefix = self.__format_timestamp(end_timestamp)
+                summary = f"{timestamp_prefix}\n{summary}"
+            return summary
+        logger.info("Conversation summary not saved. Not enough dialogue spoken.")
         return ""
 
     @utils.time_it
@@ -343,22 +353,19 @@ class Summaries(Remembering):
         # if summaries token limit is reached, summarize the summaries
         if count_tokens_summaries > summary_limit:
             logger.info(f'Token limit of conversation summaries reached ({count_tokens_summaries} / {summary_limit} tokens). Creating new summary file...')
-            while True:
-                try:
-                    prompt = self.__resummarize_prompt.format(
-                        name=npc_name,
-                        language=self.__language_name,
-                        game=self.__game.game_name_in_filepath,
-                        player_name=player_name,
-                        gender=npc_gender,
-                        race=npc_race
-                    )
-                    long_conversation_summary = self.summarize_conversation(conversation_summaries, prompt)
-                    break
-                except Exception:
-                    logger.error('Failed to summarize conversation. Retrying...')
-                    time.sleep(5)
-                    continue
+            prompt = self.__resummarize_prompt.format(
+                name=npc_name,
+                language=self.__language_name,
+                game=self.__game.game_name_in_filepath,
+                player_name=player_name,
+                gender=npc_gender,
+                race=npc_race
+            )
+            prompt = f"{prompt.rstrip()}\n\n{TRANSIENT_STATE_SUMMARY_RULE}"
+            long_conversation_summary = self.summarize_conversation(conversation_summaries, prompt)
+            if not long_conversation_summary:
+                logger.error("Summary compaction failed; retaining the existing summary file")
+                return
 
             # Split the file path and increment the number by 1
             base_directory, filename = os.path.split(conversation_summary_file)
@@ -393,9 +400,24 @@ class Summaries(Remembering):
             logger.log(23, f'Summary prompt sent to LLM: {prompt.strip()}')
             messages = message_thread(self.__config, prompt)
             messages.add_message(UserMessage(self.__config, text_to_summarize))
-            summary = self.__client.request_call(messages)
+            logger.info(
+                "Generating conversation summary using %s LLM at %s",
+                "dedicated summary" if self.__summary_client else "dialogue compatibility",
+                self.__client.base_url,
+            )
+            summary = ""
+            for attempt in range(1, self.SUMMARY_MAX_ATTEMPTS + 1):
+                try:
+                    summary = self.__client.request_call(messages) or ""
+                except Exception as exc:
+                    logger.warning("Summary attempt %d/%d failed: %s", attempt, self.SUMMARY_MAX_ATTEMPTS, exc)
+                if summary:
+                    break
+                if attempt < self.SUMMARY_MAX_ATTEMPTS:
+                    logger.warning("Summary attempt %d/%d returned no result; retrying", attempt, self.SUMMARY_MAX_ATTEMPTS)
+                    time.sleep(self.SUMMARY_RETRY_DELAY_SECONDS)
             if not summary:
-                logger.error(f"Summarizing conversation failed.")
+                logger.error("Conversation summary failed after %d attempts; continuing without saving it", self.SUMMARY_MAX_ATTEMPTS)
                 return ""
 
             summary = summary.replace('The assistant', 'Someone')

--- a/src/ui/settings_ui_constructor.py
+++ b/src/ui/settings_ui_constructor.py
@@ -241,8 +241,27 @@ class SettingsUIConstructor(ConfigValueVisitor):
             
             if has_advanced_values:
                 with gr.Accordion(label="Advanced", open=False):
-                    for cf in advanced_settings:
+                    summary_settings = [
+                        cf for cf in advanced_settings
+                        if cf.identifier in {
+                            "summary_llm_enabled",
+                            "summary_llm_api",
+                            "summary_llm",
+                            "summary_custom_token_count",
+                            "summary_llm_params",
+                        }
+                    ]
+                    other_advanced_settings = [cf for cf in advanced_settings if cf not in summary_settings]
+                    for cf in other_advanced_settings:
                         cf.accept_visitor(self)
+                    if summary_settings:
+                        with gr.Accordion(label="Summary LLM", open=False):
+                            gr.Markdown(
+                                "Enable this to generate conversation summaries with a dedicated endpoint/model. "
+                                "When disabled, summaries use the dialogue LLM."
+                            )
+                            for cf in summary_settings:
+                                cf.accept_visitor(self)
 
     def visit_ConfigValueInt(self, config_value: ConfigValueInt):
         def create_input_component(raw_config_value: ConfigValue) -> gr.Number:
@@ -412,4 +431,3 @@ class SettingsUIConstructor(ConfigValueVisitor):
             return gr.Text(value=config_value.value, show_label=False, container=False, max_lines=1)
         
         self.__create_config_value_ui_element(config_value, create_input_component, True, True, True, [("Browse...", on_pick_click)])
-

--- a/tests/llm/test_summary_client.py
+++ b/tests/llm/test_summary_client.py
@@ -1,10 +1,13 @@
 import pytest
+from unittest.mock import MagicMock, patch
 from src.config.config_loader import ConfigLoader
 from src.llm.summary_client import SummaryLLMClient
 from src.llm.client_base import ClientBase
 from src.llm.llm_client import LLMClient
 from src.remember.summaries import Summaries
 from src.games.skyrim import Skyrim
+from src.config.mantella_config_value_definitions_new import MantellaConfigValueDefinitionsNew
+from src.http.communication_constants import communication_constants
 
 
 class TestSummaryLLMClientInit:
@@ -41,8 +44,57 @@ class TestFallbackToMainClient:
         summaries = Summaries(skyrim, default_config, llm_client, english_language_info['language'], summary_client=summary_client)
         assert summaries._Summaries__client is summary_client
 
+    def test_direct_lan_summary_endpoint_is_local_and_needs_no_cloud_key(self, default_config: ConfigLoader):
+        default_config.summary_llm_api = "http://172.16.0.247:8081/v1/"
+        default_config.summary_llm = "local"
+        client = SummaryLLMClient(default_config)
+        assert client.base_url == "http://172.16.0.247:8081/v1/"
+        assert client.is_local is True
+        assert client.api_key == "abc123"
+
+    def test_summary_retries_are_bounded_and_do_not_use_dialogue_client(
+        self, skyrim: Skyrim, default_config: ConfigLoader, llm_client: LLMClient, english_language_info
+    ):
+        summary_client = MagicMock()
+        summary_client.base_url = "http://172.16.0.247:8081/v1/"
+        summary_client.request_call.return_value = None
+        summaries = Summaries(skyrim, default_config, llm_client, english_language_info['language'], summary_client=summary_client)
+
+        with patch.object(summaries, 'SUMMARY_MAX_ATTEMPTS', 3), patch('src.remember.summaries.time.sleep'), patch.object(llm_client, 'request_call') as dialogue_call:
+            result = summaries.summarize_conversation("Player: hello\nNPC: goodbye", "Summarize this")
+
+        assert result == ""
+        assert summary_client.request_call.call_count == 3
+        dialogue_call.assert_not_called()
+
+    def test_summary_retry_can_succeed_on_later_attempt(
+        self, skyrim: Skyrim, default_config: ConfigLoader, llm_client: LLMClient, english_language_info
+    ):
+        summary_client = MagicMock()
+        summary_client.base_url = "http://172.16.0.247:8081/v1/"
+        summary_client.request_call.side_effect = [None, "Recovered summary"]
+        summaries = Summaries(skyrim, default_config, llm_client, english_language_info['language'], summary_client=summary_client)
+
+        with patch('src.remember.summaries.time.sleep'):
+            result = summaries.summarize_conversation("Player: hello\nNPC: goodbye", "Summarize this")
+
+        assert result == "Recovered summary\n\n"
+        assert summary_client.request_call.call_count == 2
+
 
 class TestConfigLoadingSummaryValues:
+    def test_summary_settings_have_dedicated_gui_labels(self):
+        definitions = MantellaConfigValueDefinitionsNew.get_config_values(False)
+        expected = {
+            "summary_llm_enabled": "Enable Dedicated Summary LLM",
+            "summary_llm_api": "Summary LLM API / Endpoint",
+            "summary_llm": "Summary LLM Model",
+            "summary_custom_token_count": "Summary Custom Token Count",
+            "summary_llm_params": "Summary LLM Parameters",
+        }
+        for identifier, label in expected.items():
+            assert definitions.get_config_value_definition(identifier).name == label
+
     def test_summary_config_values_exist(self, default_config: ConfigLoader):
         """Config should have summary-specific attributes."""
         assert hasattr(default_config, "summary_llm_enabled")
@@ -64,3 +116,7 @@ class TestConfigLoadingSummaryValues:
         """summary_llm should have a default model value."""
         assert default_config.summary_llm is not None
         assert len(default_config.summary_llm) > 0
+
+
+def test_interrupted_reply_constant_is_defined():
+    assert communication_constants.KEY_REPLYTYPE_INTERRUPTED == "mantella_interrupted"


### PR DESCRIPTION
### Problem

Conversation summaries previously shared the dialogue LLM, preventing users from routing summary work to a separate model or server.

### Solution

- Adds an optional dedicated `SummaryLLMClient`.
- Adds separate summary endpoint, model, token-count, and parameter configuration.
- Adds a dedicated Summary LLM section to the GUI.
- Preserves legacy shared-client behavior when disabled.
- Keeps dialogue requests on the dialogue client.
- Dedicated summary failures do not fall back to the dialogue model.

### Validation

- Python compilation passed.
- `git diff --check` passed.
- Focused summary-client tests were added.
