### PR TITLE
Prevent stale lifecycle requests from terminating active conversations

### DIFF
--- a/src/characters_manager.py
+++ b/src/characters_manager.py
@@ -6,17 +6,23 @@ class Characters:
     """Manages a list of NPCs - both full Characters in conversation and (lightweight) nearby NPCs
     """
     def __init__(self):
+        # Ref/Form IDs are stable actor identity; display names are not unique.
         self.__active_characters: dict[str, Character] = {}
         # All NPCs who have participated since conversation start, including those who left
         self.__all_characters_since_start: dict[str, Character] = {}
         # Ordered log of (event, npc_name, message_index). event is "join" or "leave"
         self.__participation_log: list[tuple[str, str, int]] = []
+        self.__participation_log_ids: list[tuple[str, str, int]] = []
         # Lightweight nearby NPC data
         self.__nearby_npcs: list[dict[str, Any]] = []
         # List of non-participant NPCs that will receive a summary of the conversation once the conversation ends
         self.__pending_shares: list[tuple[str, str, str]] = []
         self.__last_added_character: Character | None = None
         self.__player_character: Character | None = None
+
+    @staticmethod
+    def _identity(character: Character) -> str:
+        return character.ref_id or f"base:{character.base_id}:{character.name}"
     
     def __len__(self) -> int:
         return len(self.__active_characters)
@@ -24,9 +30,10 @@ class Characters:
     @utils.time_it
     def contains_character(self, character_to_check: str | Character) -> bool:
         if isinstance(character_to_check, Character):
-            return character_to_check.name in self.__active_characters
+            return self._identity(character_to_check) in self.__active_characters
         else:
-            return character_to_check in self.__active_characters
+            return (character_to_check in self.__active_characters
+                    or any(c.name == character_to_check for c in self.__active_characters.values()))
     
     @property
     def last_added_character(self) -> Character | None:
@@ -37,27 +44,31 @@ class Characters:
     
     @utils.time_it
     def add_or_update_character(self, new_character: Character, message_count: int = 0):
-        if new_character.name not in self.__active_characters:
-            self.__active_characters[new_character.name] = new_character
+        identity = self._identity(new_character)
+        if identity not in self.__active_characters:
+            self.__active_characters[identity] = new_character
             if not new_character.is_player_character:
-                self.__all_characters_since_start[new_character.name] = new_character
+                self.__all_characters_since_start[identity] = new_character
                 self.__participation_log.append(("join", new_character.name, message_count))
+                self.__participation_log_ids.append(("join", identity, message_count))
             if new_character.is_player_character:
                 self.__player_character = new_character
             else:
                 self.__last_added_character = new_character
         else: #Is update: update transient stats + custom values
-            self.__active_characters[new_character.name].is_enemy = new_character.is_enemy
-            self.__active_characters[new_character.name].is_in_combat = new_character.is_in_combat
-            self.__active_characters[new_character.name].relationship_rank = new_character.relationship_rank
-            self.__active_characters[new_character.name].custom_character_values = new_character.custom_character_values
+            self.__active_characters[identity].is_enemy = new_character.is_enemy
+            self.__active_characters[identity].is_in_combat = new_character.is_in_combat
+            self.__active_characters[identity].relationship_rank = new_character.relationship_rank
+            self.__active_characters[identity].custom_character_values = new_character.custom_character_values
     
     @utils.time_it
     def remove_character(self, character_to_remove: Character, message_count: int = 0):
-        if character_to_remove.name in self.__active_characters:
-            del self.__active_characters[character_to_remove.name]
+        identity = self._identity(character_to_remove)
+        if identity in self.__active_characters:
+            del self.__active_characters[identity]
             if not character_to_remove.is_player_character:
                 self.__participation_log.append(("leave", character_to_remove.name, message_count))
+                self.__participation_log_ids.append(("leave", identity, message_count))
             if character_to_remove.is_player_character:
                 self.__player_character = None
             if character_to_remove == self.__last_added_character:
@@ -67,7 +78,14 @@ class Characters:
     
     @utils.time_it
     def get_character_by_name(self, name: str) -> Character:
-        return self.__active_characters[name]
+        for character in self.__active_characters.values():
+            if character.name == name:
+                return character
+        raise KeyError(name)
+
+    @utils.time_it
+    def get_character_by_ref_id(self, ref_id: str) -> Character:
+        return self.__active_characters[ref_id]
         
     @utils.time_it
     def get_all_characters(self) -> list[Character]:
@@ -79,7 +97,7 @@ class Characters:
     
     @utils.time_it
     def get_all_names(self) -> list[str]:
-        return list(self.__active_characters.keys())
+        return [character.name for character in self.__active_characters.values()]
     
     @utils.time_it
     def contains_player_character(self) -> bool:
@@ -123,7 +141,7 @@ class Characters:
             if include_player:
                 names = self.get_all_names()
             else:
-                names = [name for name, char in self.__active_characters.items() if not char.is_player_character]
+                names = [char.name for char in self.__active_characters.values() if not char.is_player_character]
             
             # Optionally add nearby NPCs
             if include_nearby:
@@ -163,3 +181,7 @@ class Characters:
     def get_participation_log(self) -> list[tuple[str, str, int]]:
         """Returns ordered list of ("join"/"leave", npc_name, message_index) events."""
         return self.__participation_log.copy()
+
+    def get_participation_log_with_ids(self) -> list[tuple[str, str, int]]:
+        """Returns ordered participation events keyed by stable actor identity."""
+        return self.__participation_log_ids.copy()

--- a/src/conversation/context.py
+++ b/src/conversation/context.py
@@ -242,7 +242,7 @@ class Context:
     
     @utils.time_it
     def __update_ingame_events_on_npc_change(self, npc: Character):
-        current_stats: Character = self.__npcs_in_conversation.get_character_by_name(npc.name)
+        current_stats: Character = self.__npcs_in_conversation.get_character_by_ref_id(npc.ref_id)
         #Is in Combat
         if current_stats.is_in_combat != npc.is_in_combat:
             name = 'The player' if npc.is_player_character else npc.name

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from threading import Thread, Lock
+from copy import deepcopy
 import time
 from typing import Any
 from src.llm.ai_client import AIClient
@@ -107,7 +108,7 @@ class Conversation:
         """
         characters_removed_by_update = self.__context.add_or_update_characters(new_character, len(self.__messages))
         if len(characters_removed_by_update) > 0:
-            self.__save_conversation(is_reload=True, departed_npcs=characters_removed_by_update)
+            self.__save_conversation(is_reload=True, departed_npcs=characters_removed_by_update, background=True)
 
     @utils.time_it
     def start_conversation(self) -> tuple[str, Sentence | None]:
@@ -159,7 +160,7 @@ class Conversation:
             if {'identifier': comm_consts.ACTION_REMOVECHARACTER} in next_sentence.actions:
                 departing_npc = next_sentence.speaker
                 self.__context.remove_character(departing_npc, len(self.__messages))
-                self.__save_conversation(is_reload=True, departed_npcs=[departing_npc])
+                self.__save_conversation(is_reload=True, departed_npcs=[departing_npc], background=True)
             #if there is a next sentence and it actually has content, return it as something for an NPC to say
             if self.last_sentence_audio_length > 0:
                 logger.debug(f'Waiting {round(self.last_sentence_audio_length, 1)} seconds for last voiceline to play')
@@ -483,10 +484,18 @@ class Conversation:
         Args:
             end_timestamp: Optional game timestamp (days passed as float) when conversation ends
         """
+        # End is idempotent.  A repeated end request (for example while the
+        # game is starting the next conversation) must not summarize the same
+        # transcript twice.
+        if self.__has_already_ended:
+            return
         self.__has_already_ended = True
         self.__stop_generation()
         self.__sentences.clear()
-        self.__save_conversation(is_reload=False, end_timestamp=end_timestamp)
+        # Detach the closed conversation from gameplay immediately.  Summary
+        # persistence operates on an immutable snapshot so it cannot block or
+        # mutate a conversation that starts afterward.
+        self.__save_conversation(is_reload=False, end_timestamp=end_timestamp, background=True)
     
     @utils.time_it
     def __start_generating_npc_sentences(self, allow_tool_use: bool = True):
@@ -527,9 +536,39 @@ class Conversation:
                 self.__sentences.put(goodbye_sentence)        
 
     @utils.time_it
-    def __save_conversation(self, is_reload: bool, departed_npcs: list[Character] | None = None, end_timestamp: float | None = None):
+    def __save_conversation(self, is_reload: bool, departed_npcs: list[Character] | None = None, end_timestamp: float | None = None, background: bool = False):
         """Saves conversation log and state for each NPC in the conversation"""
         npcs = self.__context.npcs_in_conversation
+
+        if background:
+            # Keep all state used by persistence owned by this conversation.
+            # In particular, do not let later participant/context updates
+            # leak into a summary started for an older lifecycle.
+            messages = message_thread(self.__context.config, None)
+            for message in self.__messages.get_talk_only(include_system_generated_messages=True):
+                messages.add_message(message)
+            npcs = deepcopy(npcs)
+            departed_names = {npc.name for npc in departed_npcs} if departed_npcs else None
+            world_id = self.__context.world_id
+            game_days = self.__context.game_days
+            is_radiant = isinstance(self.__conversation_type, radiant)
+            pending_shares = npcs.get_pending_shares() if not is_reload else None
+            if not is_reload:
+                self.__context.npcs_in_conversation.clear_pending_shares()
+            snapshot_npcs = npcs
+            if departed_names is None:
+                snapshot_targets = snapshot_npcs.get_non_player_characters()
+            else:
+                snapshot_targets = [
+                    npc for npc in snapshot_npcs.get_all_characters_since_start()
+                    if npc.name in departed_names
+                ]
+            Thread(
+                target=self.__save_conversation_snapshot,
+                args=(messages, snapshot_targets, snapshot_npcs, world_id, is_reload, pending_shares, end_timestamp if end_timestamp is not None else game_days, is_radiant),
+                daemon=True,
+            ).start()
+            return
 
         if departed_npcs is not None:
             npcs_to_summarize = departed_npcs
@@ -558,6 +597,45 @@ class Conversation:
 
         is_radiant = isinstance(self.__conversation_type, radiant)
         self.__rememberer.save_conversation_state(self.__messages, npcs_to_summarize, npcs, self.__context.world_id, is_reload, pending_shares, end_timestamp, is_radiant)
+
+    def __save_conversation_snapshot(
+        self,
+        messages: message_thread,
+        npcs_to_summarize: list[Character],
+        npcs_in_conversation,
+        world_id: str,
+        is_reload: bool,
+        pending_shares: list[tuple[str, str, str]] | None,
+        end_timestamp: float | None,
+        is_radiant: bool,
+    ):
+        """Persist a detached conversation snapshot without touching live state."""
+        try:
+            for npc in npcs_to_summarize:
+                conversation_log.save_conversation_log(
+                    npc,
+                    messages.transform_to_openai_messages(messages.get_talk_only()),
+                    world_id,
+                )
+
+            if not is_reload and not self.__context.config.conversation_summary_enabled:
+                logger.info("Conversation summaries disabled. Skipping summary generation.")
+                return
+
+            self.__rememberer.save_conversation_state(
+                messages,
+                npcs_to_summarize,
+                npcs_in_conversation,
+                world_id,
+                is_reload,
+                pending_shares,
+                end_timestamp,
+                is_radiant,
+            )
+        except Exception:
+            # Persistence failure must not affect the newly active gameplay
+            # conversation.  The underlying summary/client code logs details.
+            logger.exception("Detached conversation persistence failed")
 
     @utils.time_it
     def __initiate_reload_conversation(self):

--- a/src/conversation/conversation.py
+++ b/src/conversation/conversation.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from threading import Thread, Lock
 from copy import deepcopy
+from itertools import count
 import time
 from typing import Any
 from src.llm.ai_client import AIClient
@@ -25,6 +26,7 @@ import src.utils as utils
 from src.actions.function_manager import FunctionManager
 
 logger = utils.get_logger()
+_DIALOGUE_GENERATION_IDS = count(1)
 
 
 class conversation_continue_type(Enum):
@@ -68,6 +70,8 @@ class Conversation:
         self.__sentences: SentenceQueue = SentenceQueue()
         self.__generation_thread: Thread | None = None
         self.__generation_start_lock: Lock = Lock()
+        self.__pending_conversation_type_update: bool = False
+        self.__active_generation_id: int | None = None
         
         # Set up Listen action callback to apply extended pause to STT
         if stt:
@@ -98,7 +102,7 @@ class Conversation:
     @property
     def stt(self) -> Transcriber | None:
         return self.__stt
-    
+
     @utils.time_it
     def add_or_update_character(self, new_character: list[Character]):
         """Adds or updates a character in the conversation.
@@ -108,7 +112,7 @@ class Conversation:
         """
         characters_removed_by_update = self.__context.add_or_update_characters(new_character, len(self.__messages))
         if len(characters_removed_by_update) > 0:
-            self.__save_conversation(is_reload=True, departed_npcs=characters_removed_by_update, background=True)
+            self.__save_conversation(is_reload=True, departed_npcs=characters_removed_by_update)
 
     @utils.time_it
     def start_conversation(self) -> tuple[str, Sentence | None]:
@@ -135,6 +139,10 @@ class Conversation:
         """
         if self.has_already_ended:
             return comm_consts.KEY_REPLYTYPE_ENDCONVERSATION, None        
+        if self.__pending_conversation_type_update and (not self.__generation_thread or not self.__generation_thread.is_alive()):
+            self.__update_conversation_type()
+            self.__pending_conversation_type_update = False
+            self.__context.have_actors_changed = False
         if self.__llm_client.is_too_long(self.__messages, self.TOKEN_LIMIT_PERCENT):
             # Check if conversation too long and if yes initiate intermittent reload
             self.__initiate_reload_conversation()
@@ -160,7 +168,7 @@ class Conversation:
             if {'identifier': comm_consts.ACTION_REMOVECHARACTER} in next_sentence.actions:
                 departing_npc = next_sentence.speaker
                 self.__context.remove_character(departing_npc, len(self.__messages))
-                self.__save_conversation(is_reload=True, departed_npcs=[departing_npc], background=True)
+                self.__save_conversation(is_reload=True, departed_npcs=[departing_npc])
             #if there is a next sentence and it actually has content, return it as something for an NPC to say
             if self.last_sentence_audio_length > 0:
                 logger.debug(f'Waiting {round(self.last_sentence_audio_length, 1)} seconds for last voiceline to play')
@@ -242,7 +250,7 @@ class Conversation:
 
         with self.__generation_start_lock: #This lock makes sure no new generation by the LLM is started while we clear this
             self.__stop_generation() # Stop generation of additional sentences right now
-            self.__sentences.clear() # Clear any remaining sentences from the list
+            self.__sentences.clear()
 
             # If the player's input does not already exist, parse mic input if mic is enabled
             if self.__mic_input and len(player_text) == 0:
@@ -345,8 +353,15 @@ class Conversation:
         """
         self.__context.update_context(location, time, custom_ingame_events, weather, npcs_nearby, custom_context_values, config_settings, game_days)
         if self.__context.have_actors_changed:
-            self.__update_conversation_type()
-            self.__context.have_actors_changed = False
+            if self.__generation_thread and self.__generation_thread.is_alive():
+                # Keep an accepted player turn isolated from a concurrent
+                # participant refresh. The prompt/type update is applied once
+                # this generation has completed.
+                self.__pending_conversation_type_update = True
+                logger.info("Participant refresh deferred until active dialogue generation completes")
+            else:
+                self.__update_conversation_type()
+                self.__context.have_actors_changed = False
 
     @utils.time_it
     def __update_conversation_type(self):
@@ -484,18 +499,14 @@ class Conversation:
         Args:
             end_timestamp: Optional game timestamp (days passed as float) when conversation ends
         """
-        # End is idempotent.  A repeated end request (for example while the
-        # game is starting the next conversation) must not summarize the same
-        # transcript twice.
+        # A duplicate terminal request must not schedule the same detached
+        # Bug #7 summary snapshot more than once.
         if self.__has_already_ended:
             return
         self.__has_already_ended = True
         self.__stop_generation()
         self.__sentences.clear()
-        # Detach the closed conversation from gameplay immediately.  Summary
-        # persistence operates on an immutable snapshot so it cannot block or
-        # mutate a conversation that starts afterward.
-        self.__save_conversation(is_reload=False, end_timestamp=end_timestamp, background=True)
+        self.__save_conversation(is_reload=False, end_timestamp=end_timestamp)
     
     @utils.time_it
     def __start_generating_npc_sentences(self, allow_tool_use: bool = True):
@@ -509,9 +520,19 @@ class Conversation:
                     tools = FunctionManager.generate_context_aware_tools(self.__context, self.__game)
                 # Capture current OpenTelemetry context for the new thread
                 opentelemetry_context = OpenTelemetryContext.get_current()
+                generation_characters = deepcopy(self.__context.npcs_in_conversation)
+                generation_id = next(_DIALOGUE_GENERATION_IDS)
+                self.__active_generation_id = generation_id
+                logger.info(
+                    f"Dialogue generation {generation_id} started conversation={id(self)} "
+                    f"participants={[f'{c.name}:{c.ref_id}' for c in generation_characters.get_all_characters()]}"
+                )
                 def thread_target():
                     set_parent_context(opentelemetry_context)
-                    self.__output_manager.generate_response(self.__messages, self.__context.npcs_in_conversation, self.__sentences, self.context.config.actions, tools, self.__game)
+                    try:
+                        self.__output_manager.generate_response(self.__messages, generation_characters, self.__sentences, self.context.config.actions, tools, self.__game)
+                    finally:
+                        logger.info(f"Dialogue generation {generation_id} finished conversation={id(self)}")
                 self.__generation_thread = Thread(target=thread_target)
                 self.__generation_thread.start()
 
@@ -528,7 +549,7 @@ class Conversation:
     def __prepare_eject_npc_from_conversation(self, npc: Character):
         if not self.__has_already_ended:            
             self.__stop_generation()
-            self.__sentences.clear()            
+            self.__sentences.clear()
             # say goodbye
             goodbye_sentence = self.__output_manager.generate_sentence(SentenceContent(npc, self.__context.config.goodbye_npc_response, SentenceTypeEnum.SPEECH, False))
             if goodbye_sentence:
@@ -536,39 +557,9 @@ class Conversation:
                 self.__sentences.put(goodbye_sentence)        
 
     @utils.time_it
-    def __save_conversation(self, is_reload: bool, departed_npcs: list[Character] | None = None, end_timestamp: float | None = None, background: bool = False):
+    def __save_conversation(self, is_reload: bool, departed_npcs: list[Character] | None = None, end_timestamp: float | None = None):
         """Saves conversation log and state for each NPC in the conversation"""
         npcs = self.__context.npcs_in_conversation
-
-        if background:
-            # Keep all state used by persistence owned by this conversation.
-            # In particular, do not let later participant/context updates
-            # leak into a summary started for an older lifecycle.
-            messages = message_thread(self.__context.config, None)
-            for message in self.__messages.get_talk_only(include_system_generated_messages=True):
-                messages.add_message(message)
-            npcs = deepcopy(npcs)
-            departed_names = {npc.name for npc in departed_npcs} if departed_npcs else None
-            world_id = self.__context.world_id
-            game_days = self.__context.game_days
-            is_radiant = isinstance(self.__conversation_type, radiant)
-            pending_shares = npcs.get_pending_shares() if not is_reload else None
-            if not is_reload:
-                self.__context.npcs_in_conversation.clear_pending_shares()
-            snapshot_npcs = npcs
-            if departed_names is None:
-                snapshot_targets = snapshot_npcs.get_non_player_characters()
-            else:
-                snapshot_targets = [
-                    npc for npc in snapshot_npcs.get_all_characters_since_start()
-                    if npc.name in departed_names
-                ]
-            Thread(
-                target=self.__save_conversation_snapshot,
-                args=(messages, snapshot_targets, snapshot_npcs, world_id, is_reload, pending_shares, end_timestamp if end_timestamp is not None else game_days, is_radiant),
-                daemon=True,
-            ).start()
-            return
 
         if departed_npcs is not None:
             npcs_to_summarize = departed_npcs
@@ -596,46 +587,7 @@ class Conversation:
             end_timestamp = self.__context.game_days
 
         is_radiant = isinstance(self.__conversation_type, radiant)
-        self.__rememberer.save_conversation_state(self.__messages, npcs_to_summarize, npcs, self.__context.world_id, is_reload, pending_shares, end_timestamp, is_radiant)
-
-    def __save_conversation_snapshot(
-        self,
-        messages: message_thread,
-        npcs_to_summarize: list[Character],
-        npcs_in_conversation,
-        world_id: str,
-        is_reload: bool,
-        pending_shares: list[tuple[str, str, str]] | None,
-        end_timestamp: float | None,
-        is_radiant: bool,
-    ):
-        """Persist a detached conversation snapshot without touching live state."""
-        try:
-            for npc in npcs_to_summarize:
-                conversation_log.save_conversation_log(
-                    npc,
-                    messages.transform_to_openai_messages(messages.get_talk_only()),
-                    world_id,
-                )
-
-            if not is_reload and not self.__context.config.conversation_summary_enabled:
-                logger.info("Conversation summaries disabled. Skipping summary generation.")
-                return
-
-            self.__rememberer.save_conversation_state(
-                messages,
-                npcs_to_summarize,
-                npcs_in_conversation,
-                world_id,
-                is_reload,
-                pending_shares,
-                end_timestamp,
-                is_radiant,
-            )
-        except Exception:
-            # Persistence failure must not affect the newly active gameplay
-            # conversation.  The underlying summary/client code logs details.
-            logger.exception("Detached conversation persistence failed")
+        self.__rememberer.schedule_conversation_state(self.__messages, npcs_to_summarize, npcs, self.__context.world_id, is_reload, pending_shares, end_timestamp, is_radiant)
 
     @utils.time_it
     def __initiate_reload_conversation(self):

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -311,6 +311,10 @@ class GameStateManager:
     
     @utils.time_it
     def sentence_to_json(self, sentence_to_prepare: Sentence, topicID: int) -> dict[str, Any]:
+        try:
+            speaker_ref_id = int(sentence_to_prepare.speaker.ref_id, 16)
+        except (TypeError, ValueError):
+            speaker_ref_id = None
         json_dict = {
             comm_consts.KEY_ACTOR_SPEAKER: sentence_to_prepare.speaker.name,
             comm_consts.KEY_ACTOR_LINETOSPEAK: self.__abbreviate_text(sentence_to_prepare.text.strip()),
@@ -320,6 +324,12 @@ class GameStateManager:
             comm_consts.KEY_ACTOR_ACTIONS: sentence_to_prepare.actions,
             comm_consts.KEY_CONTINUECONVERSATION_TOPICINFOFILE: topicID
         }
+        if speaker_ref_id is not None:
+            json_dict[comm_consts.KEY_ACTOR_REFID] = speaker_ref_id
+        logger.debug(
+            f"NPC talk payload speaker={sentence_to_prepare.speaker.name} "
+            f"ref_id={sentence_to_prepare.speaker.ref_id} serialized_ref_id={speaker_ref_id}"
+        )
 
         return json_dict
     

--- a/src/game_manager.py
+++ b/src/game_manager.py
@@ -20,8 +20,10 @@ from src.stt.stt import Transcriber
 from src.actions.function_manager import FunctionManager
 from src.random_llm_selector import RandomLLMSelector, LLMSelection
 from src.llm.client_base import ClientBase
+from itertools import count
 
 logger = utils.get_logger()
+_MANAGER_GENERATIONS = count(1)
 
 
 class CharacterDoesNotExist(Exception):
@@ -51,13 +53,44 @@ class GameStateManager:
         self.__should_reload: bool = False
         self.__chat_manager.clear_per_character_client_cache()
         self.__random_selector = RandomLLMSelector()
+        self.__diagnostic_generation = next(_MANAGER_GENERATIONS)
+        self.__session_id: int | str | None = None
+        self.__last_session_id: int | str | None = None
+        logger.info(f"Protocol manager created: generation={self.__diagnostic_generation} object={id(self)}")
+
+    @property
+    def diagnostic_state(self) -> str:
+        conversation = self.__talk
+        if conversation is None:
+            return f"manager={self.__diagnostic_generation}/{id(self)} conversation=None active=False ended=None"
+        return (f"manager={self.__diagnostic_generation}/{id(self)} conversation={id(conversation)} "
+                f"active={not conversation.has_already_ended} ended={conversation.has_already_ended}")
+
+    @property
+    def protocol_session_id(self):
+        return self.__session_id if self.__session_id is not None else self.__last_session_id
+
+    def request_session_matches(self, input_json: dict[str, Any]) -> bool:
+        incoming = input_json.get(comm_consts.KEY_CONVERSATION_SESSION)
+        return incoming is None or self.__session_id is None or str(incoming) == str(self.__session_id)
+
+    def stale_request_reply(self, request_type: str, incoming_session: Any) -> dict[str, Any]:
+        logger.warning(f"Protocol stale request ignored: type={request_type} incoming_session={incoming_session} active_session={self.protocol_session_id}")
+        return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTYPE_STALE_REQUEST,
+                comm_consts.KEY_CONVERSATION_SESSION: self.protocol_session_id}
 
 
     @utils.time_it
     def start_conversation(self, input_json: dict[str, Any]) -> dict[str, Any]:
+        previous = id(self.__talk) if self.__talk else None
+        logger.info(f"Protocol start_conversation: {self.diagnostic_state} previous_conversation={previous}")
         if self.__talk: #This should only happen if game and server are out of sync due to some previous error -> close conversation and start a new one
             self.__talk.end()
             self.__talk = None
+
+        incoming_session = input_json.get(comm_consts.KEY_CONVERSATION_SESSION)
+        self.__session_id = incoming_session if incoming_session is not None else f"manager-{self.__diagnostic_generation}-{time.time_ns()}"
+        self.__last_session_id = self.__session_id
 
         world_id = "default"
         if input_json.__contains__(comm_consts.KEY_STARTCONVERSATION_WORLDID):
@@ -70,13 +103,20 @@ class GameStateManager:
         conversation_client = self._build_random_conversation_client() or self.__client
         context_for_conversation = Context(world_id, self.__config, conversation_client, self.__rememberer, self.__language_info)
         self.__talk = Conversation(context_for_conversation, self.__chat_manager, self.__rememberer, conversation_client, self.__stt, self.__mic_input, self.__mic_ptt, self.__game)
+        logger.info(f"Protocol conversation created: {self.diagnostic_state}")
         self.__update_context(input_json)
         self.__try_preload_voice_model()
         self.__talk.start_conversation()
             
         return {
             comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTTYPE_STARTCONVERSATIONCOMPLETED,
-            comm_consts.KEY_STARTCONVERSATION_USENARRATOR: self.__conv_has_narrator}
+            comm_consts.KEY_STARTCONVERSATION_USENARRATOR: self.__conv_has_narrator,
+            comm_consts.KEY_CONVERSATION_SESSION: self.__session_id}
+
+    @property
+    def has_active_conversation(self) -> bool:
+        """Whether this manager currently owns a live gameplay conversation."""
+        return self.__talk is not None and not self.__talk.has_already_ended
     
 
     def _build_random_conversation_client(self) -> ClientBase | None:
@@ -113,7 +153,9 @@ class GameStateManager:
     
     @utils.time_it
     def continue_conversation(self, input_json: dict[str, Any]) -> dict[str, Any]:
+        logger.info(f"Protocol continue_conversation entry: {self.diagnostic_state}")
         if(not self.__talk ):
+            logger.warning("Protocol continue_conversation rejected: no active conversation")
             return self.error_message("No running conversation.")
         
         # comm_consts.KEY_INPUTTYPE is passed when the mic settings have been changed in the MCM since beginning the conversation
@@ -138,6 +180,7 @@ class GameStateManager:
                 # Player input was detected mid-response: tell the game to cut the current voiceline
                 # the game follows up with a player input request, which goes through player_input() normally
                 # (setting __first_line = True) so the streamed first line is correctly muted in-game
+                logger.info(f"Protocol interrupted reply: {self.diagnostic_state}")
                 return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTYPE_INTERRUPTED}
             elif replyType == comm_consts.KEY_REPLYTYPE_NPCACTION:
                 # Action-only response (no voiceline)
@@ -175,12 +218,14 @@ class GameStateManager:
 
     @utils.time_it
     def player_input(self, input_json: dict[str, Any]) -> dict[str, Any]:
+        player_text = input_json.get(comm_consts.KEY_REQUESTTYPE_PLAYERINPUT, '') or ''
+        logger.info(f"Protocol player_input entry: {self.diagnostic_state} text_length={len(player_text)} text_prefix={player_text[:80]!r}")
         if(not self.__talk ):
+            logger.warning("Protocol player_input rejected: no active conversation")
             return self.error_message("No running conversation.")
         
         self.__first_line = True
         
-        player_text: str = input_json.get(comm_consts.KEY_REQUESTTYPE_PLAYERINPUT, '')
         self.__update_context(input_json)
         updated_player_text, update_events, player_spoken_sentence = self.__talk.process_player_input(player_text)
         if update_events:
@@ -215,6 +260,7 @@ class GameStateManager:
 
         # if the player response is not an action command, return a regular player reply type
         if player_spoken_sentence:
+            logger.info(f"Protocol player_input dispatched: {self.diagnostic_state} text_prefix={player_spoken_sentence.text[:80]!r}")
             topicInfoID: int = int(input_json.get(comm_consts.KEY_CONTINUECONVERSATION_TOPICINFOFILE,1))
             self.__game.prepare_sentence_for_game(player_spoken_sentence, self.__talk.context, self.__config, topicInfoID, self.__first_line)
             self.__first_line = False
@@ -224,16 +270,20 @@ class GameStateManager:
 
     @utils.time_it
     def end_conversation(self, input_json: dict[str, Any]) -> dict[str, Any]:
+        ending_conversation = id(self.__talk) if self.__talk else None
+        logger.info(f"Protocol end_conversation: {self.diagnostic_state} ending_conversation={ending_conversation} timestamp={input_json.get(comm_consts.KEY_ENDCONVERSATION_TIMESTAMP)}")
         if(self.__talk):
             # Extract end timestamp from game client
             end_timestamp = input_json.get(comm_consts.KEY_ENDCONVERSATION_TIMESTAMP, None)
             self.__talk.end(end_timestamp)
             self.__talk = None
+            logger.info(f"Protocol conversation cleared: {self.diagnostic_state} ended_conversation={ending_conversation}")
 
         logger.log(24, '\nConversations not starting when you select an NPC? See here:')
         logger.log(25, 'https://art-from-the-machine.github.io/Mantella/pages/issues_qna')
         logger.log(24, '\nWaiting for player to select an NPC...')
-        return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTYPE_ENDCONVERSATION}
+        return {comm_consts.KEY_REPLYTYPE: comm_consts.KEY_REPLYTYPE_ENDCONVERSATION,
+                comm_consts.KEY_CONVERSATION_SESSION: self.__last_session_id}
     
     def process_stt_setup(self, input_json: dict[str, Any]):
         '''Process the STT setup (mic / text / push-to-talk) based on the settings passed in the input JSON'''

--- a/src/http/communication_constants.py
+++ b/src/http/communication_constants.py
@@ -20,6 +20,8 @@ class communication_constants:
     KEY_REPLYTYPE_PLAYERTALK: str  = PREFIX + "player_talk"
     KEY_REPLYTYPE_ENDCONVERSATION: str  = PREFIX + "end_conversation"
     KEY_REPLYTYPE_INTERRUPTED: str  = PREFIX + "interrupted"
+    KEY_REPLYTYPE_STALE_REQUEST: str = PREFIX + "stale_request"
+    KEY_CONVERSATION_SESSION: str = PREFIX + "conversation_session"
 
     KEY_STARTCONVERSATION_WORLDID: str = PREFIX + "worldid"
     KEY_STARTCONVERSATION_USENARRATOR: str = PREFIX + "use_narrator"

--- a/src/http/routes/mantella_route.py
+++ b/src/http/routes/mantella_route.py
@@ -32,6 +32,8 @@ class mantella_route(routeable):
         super().__init__(config)
         self.__language_info: dict[Hashable, str] = language_info
         self.__game: GameStateManager | None = None
+        self.__route_reinitialization_pending: bool = False
+        self.__request_sequence: int = 0
 
         # if not self._can_route_be_used():
         #     error_message = "MantellaSoftware settings faulty. Please check MantellaSoftware's window or log."
@@ -40,6 +42,14 @@ class mantella_route(routeable):
     @utils.time_it
     def _setup_route(self):
         if self.__game:
+            # A config edit can be observed on the first request after a new
+            # conversation starts (including its first STT input). Never let
+            # route reinitialization terminate that live session and swallow
+            # its input. The next clean start will rebuild the clients.
+            if self.__game.has_active_conversation:
+                logger.info(f"Protocol route reinitialization deferred: {self.__game.diagnostic_state}")
+                self.__route_reinitialization_pending = True
+                return
             self.__game.end_conversation({})
 
         game: Gameable
@@ -51,34 +61,56 @@ class mantella_route(routeable):
 
         tts: TTSable = create_tts(self._config.tts_service, self._config, game)
 
-        llm_client = LLMClient(self._config)
+        dialogue_client = LLMClient(self._config)
 
         summary_client: SummaryLLMClient | None = None
         if self._config.summary_llm_enabled:
             summary_client = SummaryLLMClient(self._config)
 
-        chat_manager = ChatManager(self._config, tts, llm_client, game)
-        self.__game = GameStateManager(game, chat_manager, self._config, self.__language_info, llm_client, summary_client)
+        chat_manager = ChatManager(self._config, tts, dialogue_client, game)
+        self.__game = GameStateManager(game, chat_manager, self._config, self.__language_info, dialogue_client, summary_client)
+        logger.info(f"Protocol route manager ready: {self.__game.diagnostic_state}")
 
     @utils.time_it
     def add_route_to_server(self, app: FastAPI):
         @app.post("/mantella")
         async def mantella(request: Request):
+            received_json: dict[str, Any] | None = await request.json()
+            self.__request_sequence += 1
+            request_sequence = self.__request_sequence
+            request_type = received_json.get(comm_consts.KEY_REQUESTTYPE, "<missing>") if received_json else "<empty>"
+            before_state = self.__game.diagnostic_state if self.__game else "manager=None"
+            has_player_text = bool(received_json and received_json.get(comm_consts.KEY_REQUESTTYPE_PLAYERINPUT))
+            incoming_session = received_json.get(comm_consts.KEY_CONVERSATION_SESSION) if received_json else None
+            logger.info(f"Protocol request #{request_sequence} received: type={request_type} incoming_session={incoming_session} before={before_state} has_player_input={has_player_text}")
             if not self._can_route_be_used():
                 error_message = "MantellaSoftware settings faulty. Please check MantellaSoftware's window or log."
                 logger.error(error_message)
+                logger.info(f"Protocol request #{request_sequence} rejected: route unavailable after={self.__game.diagnostic_state if self.__game else 'manager=None'}")
                 return self.error_message(error_message)
             if not self.__game:
                 error_message = "Game manager setup failed. There is most likely an issue with the config.ini."
                 logger.error(error_message)
                 return self.error_message(error_message)
             reply = {}
-            received_json: dict[str, Any] | None = await request.json()
             if received_json:
                 logger.debug('Processing request...')
                 if self._config.show_http_debug_messages:
                     logger.log(self._log_level_http_in, json.dumps(received_json, indent=4))
                 request_type: str = received_json[comm_consts.KEY_REQUESTTYPE]
+                incoming_session = received_json.get(comm_consts.KEY_CONVERSATION_SESSION)
+                if (request_type != comm_consts.KEY_REQUESTTYPE_STARTCONVERSATION
+                        and incoming_session is not None
+                        and not self.__game.request_session_matches(received_json)):
+                    reply = self.__game.stale_request_reply(request_type, incoming_session)
+                    logger.info(f"Protocol request #{request_sequence} stale: type={request_type} incoming_session={incoming_session} active={self.__game.protocol_session_id}")
+                    return reply
+                if request_type == comm_consts.KEY_REQUESTTYPE_STARTCONVERSATION and self.__route_reinitialization_pending:
+                    # The old conversation is replaced as part of this start;
+                    # rebuild clients before creating the new session.
+                    self.__game = None
+                    self.__route_reinitialization_pending = False
+                    self._setup_route()
                 match request_type:
                     case comm_consts.KEY_REQUESTTYPE_INIT:
                         # nothing needs to be done for this request aside from self._can_route_be_used() being triggered
@@ -99,4 +131,7 @@ class mantella_route(routeable):
 
             if self._config.show_http_debug_messages:
                 logger.log(self._log_level_http_out, json.dumps(reply, indent=4))
+            logger.info(f"Protocol request #{request_sequence} completed: type={request_type} after={self.__game.diagnostic_state if self.__game else 'manager=None'} reply_type={reply.get(comm_consts.KEY_REPLYTYPE, '<missing>')}")
+            if self.__game and comm_consts.KEY_CONVERSATION_SESSION not in reply:
+                reply[comm_consts.KEY_CONVERSATION_SESSION] = self.__game.protocol_session_id
             return reply

--- a/src/remember/summaries.py
+++ b/src/remember/summaries.py
@@ -1,6 +1,9 @@
 from collections import defaultdict
 import os
 import time
+import copy
+from concurrent.futures import Future, ThreadPoolExecutor
+from itertools import count
 from typing import Dict, List
 from src.config.config_loader import ConfigLoader
 from src.config.definitions.game_definitions import GameEnum
@@ -39,6 +42,8 @@ class Summaries(Remembering):
         self.__language_name: str = language_name
         self.__memory_prompt: str = config.memory_prompt
         self.__resummarize_prompt: str = config.resummarize_prompt
+        self.__summary_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="MantellaSummary")
+        self.__summary_job_ids = count(1)
 
     def __read_summary_lines(self, file_path: str, deduplicate: bool = False) -> list[str]:
         """Read a summary file and return non-empty stripped lines.
@@ -107,8 +112,8 @@ class Summaries(Remembering):
         npc_message_threads: Dict[str, CharacterSummaryParameters] = self.get_threads_for_summarization(messages, npcs_in_conversation)
 
         # Filter to only the NPCs the caller wants summarized
-        names_to_summarize = {c.name for c in npcs_to_summarize}
-        npc_message_threads = {name: params for name, params in npc_message_threads.items() if name in names_to_summarize}
+        target_keys = {self.__summary_key(c, npcs_in_conversation.get_all_characters_since_start()) for c in npcs_to_summarize}
+        npc_message_threads = {key: params for key, params in npc_message_threads.items() if key in target_keys}
 
         npcs_with_shared_threads = self.group_shared_threads(npc_message_threads)
 
@@ -129,7 +134,7 @@ class Summaries(Remembering):
             for npc_name in npc_names:
                 npc_summaries[npc_name] = summary
                 if summary or is_reload:
-                    character = next(c for c in npcs_to_summarize if c.name == npc_name)
+                    character = next(c for c in npcs_to_summarize if self.__summary_key(c, npcs_in_conversation.get_all_characters_since_start()) == npc_name)
                     self.__append_new_conversation_summary(summary, character.name, character.ref_id, world_id, player_name, npc_gender=character.gender, npc_race=character.race)
 
         # Handle pending shares: write summary with prefix to recipient folders
@@ -158,6 +163,48 @@ class Summaries(Remembering):
                 self.__append_new_conversation_summary(prefixed_summary, recipient_name, recipient_ref_id, world_id, player_name)
                 logger.info(f"Shared conversation summary with {recipient_name}")
 
+    def schedule_conversation_state(self, messages: message_thread, npcs_to_summarize: list[Character], npcs_in_conversation: Characters, world_id: str, is_reload=False, pending_shares: list[tuple[str, str, str]] | None = None, end_timestamp: float | None = None, is_radiant: bool = False) -> Future:
+        """Queue an isolated summary snapshot so dialogue does not wait on summary inference."""
+        job_id = next(self.__summary_job_ids)
+        message_snapshot = messages.snapshot()
+        npc_snapshot = copy.deepcopy(npcs_in_conversation)
+        targets_snapshot = copy.deepcopy(npcs_to_summarize)
+        shares_snapshot = list(pending_shares) if pending_shares else None
+        logger.info(f"Summary job {job_id} scheduled reload={is_reload} targets={[npc.name for npc in targets_snapshot]}")
+        future = self.__summary_executor.submit(
+            self.__run_scheduled_summary,
+            job_id,
+            message_snapshot,
+            targets_snapshot,
+            npc_snapshot,
+            world_id,
+            is_reload,
+            shares_snapshot,
+            end_timestamp,
+            is_radiant,
+        )
+        future.add_done_callback(lambda completed: self.__summary_done(job_id, completed))
+        return future
+
+    def __run_scheduled_summary(self, job_id: int, messages: message_thread, npcs_to_summarize: list[Character], npcs_in_conversation: Characters, world_id: str, is_reload: bool, pending_shares: list[tuple[str, str, str]] | None, end_timestamp: float | None, is_radiant: bool) -> None:
+        logger.debug(f"Summary job {job_id} worker started")
+        self.save_conversation_state(messages, npcs_to_summarize, npcs_in_conversation, world_id, is_reload, pending_shares, end_timestamp, is_radiant)
+
+    def __summary_done(self, job_id: int, future: Future) -> None:
+        if future.cancelled():
+            logger.warning(f"Summary job {job_id} cancelled before completion")
+            return
+        error = future.exception()
+        if error is not None:
+            logger.error(f"Summary job {job_id} failed: {error}")
+        else:
+            logger.debug(f"Summary job {job_id} completed and persisted")
+
+    def shutdown(self, wait: bool = False) -> None:
+        """Stop accepting summary jobs without blocking the active dialogue path."""
+        logger.info(f"Summary executor shutdown requested wait={wait}")
+        self.__summary_executor.shutdown(wait=wait, cancel_futures=False)
+
     @utils.time_it
     def get_threads_for_summarization(self, all_messages: message_thread, npcs_in_conversation: Characters) -> Dict[str, CharacterSummaryParameters]:
         """Returns a dictionary mapping an NPC's name to a CharacterSummaryParameters object,
@@ -166,28 +213,32 @@ class Summaries(Remembering):
         Uses the participation log from Characters to determine which messages each NPC heard,
         based on their join/leave message indices.
         """
-        participation_log = npcs_in_conversation.get_participation_log()
+        participation_log = npcs_in_conversation.get_participation_log_with_ids()
         all_chars_since_start = npcs_in_conversation.get_all_characters_since_start()
         total_messages = len(all_messages)
+        chars_by_id = {
+            c.ref_id or f"base:{c.base_id}:{c.name}": c
+            for c in all_chars_since_start
+        }
 
         # Build intervals for each NPC: list of (start_index, end_index)
         npc_intervals: Dict[str, list[tuple[int, int]]] = {}
         open_joins: Dict[str, int] = {}
 
-        for event, name, msg_index in participation_log:
+        for event, identity, msg_index in participation_log:
             if event == "join":
-                open_joins[name] = msg_index
-            elif event == "leave" and name in open_joins:
-                start = open_joins.pop(name)
-                npc_intervals.setdefault(name, []).append((start, msg_index))
+                open_joins[identity] = msg_index
+            elif event == "leave" and identity in open_joins:
+                start = open_joins.pop(identity)
+                npc_intervals.setdefault(identity, []).append((start, msg_index))
 
         # Close any open joins (NPCs still in conversation at save time)
-        for name, start in open_joins.items():
-            npc_intervals.setdefault(name, []).append((start, total_messages))
+        for identity, start in open_joins.items():
+            npc_intervals.setdefault(identity, []).append((start, total_messages))
 
         # Build per-NPC threads
         result: Dict[str, CharacterSummaryParameters] = {}
-        for npc_name, intervals in npc_intervals.items():
+        for identity, intervals in npc_intervals.items():
             start, end = intervals[-1]
 
             thread = message_thread(self.__config, None)
@@ -197,19 +248,25 @@ class Summaries(Remembering):
                     thread.add_message(msg)
 
             # Find other NPCs who were present during this NPC's latest interval
-            involved: set[str] = {npc_name}
-            for other_name, other_intervals in npc_intervals.items():
-                if other_name == npc_name:
+            involved: set[str] = {identity}
+            for other_identity, other_intervals in npc_intervals.items():
+                if other_identity == identity:
                     continue
                 for other_start, other_end in other_intervals:
                     if start < other_end and other_start < end:
-                        involved.add(other_name)
+                        involved.add(other_identity)
                         break
 
-            involved_chars = [c for c in all_chars_since_start if c.name in involved]
-            result[npc_name] = CharacterSummaryParameters(thread, involved_chars)
+            involved_chars = [chars_by_id[ref] for ref in involved if ref in chars_by_id]
+            character = chars_by_id[identity]
+            result[self.__summary_key(character, all_chars_since_start)] = CharacterSummaryParameters(thread, involved_chars)
 
         return result
+
+    @staticmethod
+    def __summary_key(character: Character, all_characters: list[Character]) -> str:
+        same_name = sum(c.name == character.name for c in all_characters)
+        return character.name if same_name == 1 else f"{character.name} [{character.ref_id}]"
 
     def group_shared_threads(self, npc_threads: Dict[str, CharacterSummaryParameters]) -> list[list[str]]:
         """Groups NPC message threads if they have exactly the same messages.

--- a/tests/conversation/test_conversation_lifecycle.py
+++ b/tests/conversation/test_conversation_lifecycle.py
@@ -22,7 +22,6 @@ def test_end_detaches_once_and_starts_background_persistence():
     conversation._Conversation__save_conversation.assert_called_once_with(
         is_reload=False,
         end_timestamp=None,
-        background=True,
     )
     assert conversation._Conversation__stop_generation.call_count == 1
 
@@ -44,45 +43,18 @@ class _SnapshotCharacters:
         return []
 
 
-def test_background_save_uses_detached_snapshot_and_clears_only_old_shares(monkeypatch):
+def test_summary_schedule_uses_rememberer_executor():
     conversation = Conversation.__new__(Conversation)
-    config = MagicMock(conversation_summary_enabled=True)
-    characters = _SnapshotCharacters()
-    context = MagicMock(config=config, world_id="conversation-a", game_days=12.5)
-    context.npcs_in_conversation = characters
-    conversation._Conversation__context = context
+    conversation._Conversation__context = MagicMock()
+    conversation._Conversation__context.npcs_in_conversation = _SnapshotCharacters()
+    conversation._Conversation__context.world_id = "conversation-a"
     conversation._Conversation__messages = MagicMock()
-    conversation._Conversation__messages.get_talk_only.return_value = []
     conversation._Conversation__conversation_type = MagicMock()
     conversation._Conversation__rememberer = MagicMock()
 
-    queued = {}
+    conversation._Conversation__save_conversation(is_reload=False, end_timestamp=None)
 
-    class ImmediateThread:
-        def __init__(self, target, args, daemon):
-            queued["target"] = target
-            queued["args"] = args
-            queued["daemon"] = daemon
-
-        def start(self):
-            queued["started"] = True
-
-    monkeypatch.setattr("src.conversation.conversation.Thread", ImmediateThread)
-    conversation._Conversation__save_conversation(
-        is_reload=False,
-        end_timestamp=None,
-        background=True,
-    )
-
-    assert queued["started"] is True
-    assert queued["daemon"] is True
-    assert characters.pending_shares == []
-    # Execute the detached job after the live conversation would be replaced.
-    queued["target"](*queued["args"])
-    conversation._Conversation__rememberer.save_conversation_state.assert_called_once()
-    args = conversation._Conversation__rememberer.save_conversation_state.call_args.args
-    assert args[3] == "conversation-a"
-    assert args[5] == [("A", "B", "ref-b")]
+    conversation._Conversation__rememberer.schedule_conversation_state.assert_called_once()
 
 
 def test_participant_removal_uses_detached_persistence(monkeypatch):
@@ -100,5 +72,4 @@ def test_participant_removal_uses_detached_persistence(monkeypatch):
     conversation._Conversation__save_conversation.assert_called_once_with(
         is_reload=True,
         departed_npcs=[removed],
-        background=True,
     )

--- a/tests/conversation/test_conversation_lifecycle.py
+++ b/tests/conversation/test_conversation_lifecycle.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock
+
+from src.conversation.conversation import Conversation
+
+
+def _ended_conversation_stub() -> Conversation:
+    conversation = Conversation.__new__(Conversation)
+    conversation._Conversation__has_already_ended = False
+    conversation._Conversation__stop_generation = MagicMock()
+    conversation._Conversation__sentences = MagicMock()
+    conversation._Conversation__save_conversation = MagicMock()
+    return conversation
+
+
+def test_end_detaches_once_and_starts_background_persistence():
+    conversation = _ended_conversation_stub()
+
+    conversation.end()
+    conversation.end()
+
+    assert conversation._Conversation__save_conversation.call_count == 1
+    conversation._Conversation__save_conversation.assert_called_once_with(
+        is_reload=False,
+        end_timestamp=None,
+        background=True,
+    )
+    assert conversation._Conversation__stop_generation.call_count == 1
+
+
+class _SnapshotCharacters:
+    def __init__(self):
+        self.pending_shares = [("A", "B", "ref-b")]
+
+    def get_pending_shares(self):
+        return list(self.pending_shares)
+
+    def clear_pending_shares(self):
+        self.pending_shares.clear()
+
+    def get_non_player_characters(self):
+        return []
+
+    def get_all_characters_since_start(self):
+        return []
+
+
+def test_background_save_uses_detached_snapshot_and_clears_only_old_shares(monkeypatch):
+    conversation = Conversation.__new__(Conversation)
+    config = MagicMock(conversation_summary_enabled=True)
+    characters = _SnapshotCharacters()
+    context = MagicMock(config=config, world_id="conversation-a", game_days=12.5)
+    context.npcs_in_conversation = characters
+    conversation._Conversation__context = context
+    conversation._Conversation__messages = MagicMock()
+    conversation._Conversation__messages.get_talk_only.return_value = []
+    conversation._Conversation__conversation_type = MagicMock()
+    conversation._Conversation__rememberer = MagicMock()
+
+    queued = {}
+
+    class ImmediateThread:
+        def __init__(self, target, args, daemon):
+            queued["target"] = target
+            queued["args"] = args
+            queued["daemon"] = daemon
+
+        def start(self):
+            queued["started"] = True
+
+    monkeypatch.setattr("src.conversation.conversation.Thread", ImmediateThread)
+    conversation._Conversation__save_conversation(
+        is_reload=False,
+        end_timestamp=None,
+        background=True,
+    )
+
+    assert queued["started"] is True
+    assert queued["daemon"] is True
+    assert characters.pending_shares == []
+    # Execute the detached job after the live conversation would be replaced.
+    queued["target"](*queued["args"])
+    conversation._Conversation__rememberer.save_conversation_state.assert_called_once()
+    args = conversation._Conversation__rememberer.save_conversation_state.call_args.args
+    assert args[3] == "conversation-a"
+    assert args[5] == [("A", "B", "ref-b")]
+
+
+def test_participant_removal_uses_detached_persistence(monkeypatch):
+    conversation = Conversation.__new__(Conversation)
+    conversation._Conversation__messages = MagicMock()
+    conversation._Conversation__messages.__len__.return_value = 4
+    removed = object()
+    context = MagicMock()
+    context.add_or_update_characters.return_value = [removed]
+    conversation._Conversation__context = context
+    conversation._Conversation__save_conversation = MagicMock()
+
+    conversation.add_or_update_character([])
+
+    conversation._Conversation__save_conversation.assert_called_once_with(
+        is_reload=True,
+        departed_npcs=[removed],
+        background=True,
+    )

--- a/tests/http/routes/test_conversation_restart_guard.py
+++ b/tests/http/routes/test_conversation_restart_guard.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.game_manager import GameStateManager
+from src.http.communication_constants import communication_constants as comm_consts
+from src.http.routes.mantella_route import mantella_route
+
+
+def test_game_manager_reports_only_live_conversations():
+    manager = GameStateManager.__new__(GameStateManager)
+    manager._GameStateManager__talk = MagicMock(has_already_ended=False)
+    assert manager.has_active_conversation is True
+
+    manager._GameStateManager__talk.has_already_ended = True
+    assert manager.has_active_conversation is False
+
+
+def test_game_manager_diagnostic_state_identifies_conversation():
+    manager = GameStateManager.__new__(GameStateManager)
+    manager._GameStateManager__diagnostic_generation = 7
+    manager._GameStateManager__talk = None
+    assert "manager=7/" in manager.diagnostic_state
+    assert "conversation=None" in manager.diagnostic_state
+
+    manager._GameStateManager__talk = MagicMock(has_already_ended=False)
+    assert "conversation=" in manager.diagnostic_state
+    assert "active=True" in manager.diagnostic_state
+
+
+def test_stale_session_terminal_request_is_rejected_without_clearing_active_state():
+    manager = GameStateManager.__new__(GameStateManager)
+    manager._GameStateManager__session_id = 2
+    manager._GameStateManager__last_session_id = 2
+    assert manager.request_session_matches({"mantella_conversation_session": 2})
+    assert not manager.request_session_matches({"mantella_conversation_session": 1})
+    reply = manager.stale_request_reply("mantella_end_conversation", 1)
+    assert reply["mantella_reply_type"] == "mantella_stale_request"
+    assert reply["mantella_conversation_session"] == 2
+
+
+def test_legacy_request_without_session_remains_compatible():
+    manager = GameStateManager.__new__(GameStateManager)
+    manager._GameStateManager__session_id = 2
+    assert manager.request_session_matches({})
+
+
+def test_new_session_is_returned_by_start_response():
+    manager = GameStateManager.__new__(GameStateManager)
+    manager._GameStateManager__session_id = "B"
+    manager._GameStateManager__last_session_id = "B"
+    assert manager.protocol_session_id == "B"
+
+
+def test_route_reinitialization_does_not_end_active_conversation():
+    route = mantella_route.__new__(mantella_route)
+    active_manager = MagicMock(has_active_conversation=True)
+    route._mantella_route__game = active_manager
+    route._mantella_route__route_reinitialization_pending = False
+
+    route._setup_route()
+
+    active_manager.end_conversation.assert_not_called()
+    assert route._mantella_route__route_reinitialization_pending is True
+
+
+def test_first_player_input_survives_deferred_route_reinitialization():
+    """A config reload observed on B's first request must not end B first."""
+    route = mantella_route.__new__(mantella_route)
+
+    class Config:
+        has_any_config_value_changed = True
+        have_all_config_values_loaded_correctly = True
+        show_http_debug_messages = False
+
+        def update_config_loader_with_changed_config_values(self):
+            self.has_any_config_value_changed = False
+
+    manager = MagicMock(has_active_conversation=True)
+    manager.player_input.return_value = {"mantella_reply_type": "mantella_npc_talk"}
+    route._config = Config()
+    route._has_route_been_initialized = True
+    route._mantella_route__game = manager
+    route._mantella_route__route_reinitialization_pending = False
+    route._mantella_route__request_sequence = 0
+
+    app = FastAPI()
+    route.add_route_to_server(app)
+    response = TestClient(app).post(
+        "/mantella",
+        json={
+            comm_consts.KEY_REQUESTTYPE: comm_consts.KEY_REQUESTTYPE_PLAYERINPUT,
+            comm_consts.KEY_REQUESTTYPE_PLAYERINPUT: "Hey, Lydia, how's it going?",
+        },
+    )
+
+    assert response.status_code == 200
+    manager.player_input.assert_called_once()
+    manager.end_conversation.assert_not_called()
+    assert route._mantella_route__route_reinitialization_pending is True

--- a/tests/remember/test_summaries.py
+++ b/tests/remember/test_summaries.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import logging
+import threading
 from unittest.mock import patch
 from src.config.config_loader import ConfigLoader
 from src.config.definitions.game_definitions import GameEnum
@@ -23,6 +24,23 @@ def _build_enough_messages(thread: message_thread, config: ConfigLoader, count: 
 
 
 class TestPerNpcThreadExtraction:
+    def test_same_name_actors_get_independent_summary_threads(self, default_config: ConfigLoader, default_rememberer: Summaries, example_skyrim_npc_character: Character, another_example_skyrim_npc_character: Character):
+        first = example_skyrim_npc_character
+        second = another_example_skyrim_npc_character
+        second.name = first.name
+        thread = message_thread(default_config, "system prompt")
+        characters = Characters()
+        characters.add_or_update_character(first, len(thread))
+        thread.add_message(UserMessage(default_config, "Hello first", "Player"))
+        thread.add_message(AssistantMessage(default_config))
+        characters.remove_character(first, len(thread))
+        characters.add_or_update_character(second, len(thread))
+        thread.add_message(UserMessage(default_config, "Hello second", "Player"))
+        thread.add_message(AssistantMessage(default_config))
+        characters.remove_character(second, len(thread))
+        npc_threads = default_rememberer.get_threads_for_summarization(thread, characters)
+        assert set(npc_threads) == {f"{first.name} [{first.ref_id}]", f"{second.name} [{second.ref_id}]"}
+
     def test_single_npc_gets_all_messages(self, default_config: ConfigLoader, default_rememberer: Summaries, example_skyrim_npc_character: Character):
         """A single NPC present for the full conversation should get all messages."""
         thread = message_thread(default_config, "system prompt")
@@ -175,26 +193,80 @@ class TestConversationSummaryEnabledGating:
         assert any(self.SUMMARY_DISABLED_LOG in m for m in caplog.messages)
         assert not any(self.SUMMARY_ATTEMPTED_LOG in m for m in caplog.messages)
 
-    def test_summary_enabled_calls_save(self, default_conversation: Conversation, default_config: ConfigLoader, caplog):
-        """When conversation_summary_enabled is True, save_conversation_state should be called."""
+    def test_summary_enabled_schedules_save(self, default_conversation: Conversation, default_config: ConfigLoader, monkeypatch):
+        """When conversation_summary_enabled is True, summary persistence is scheduled."""
         default_config.conversation_summary_enabled = True
+        scheduled = []
+        monkeypatch.setattr(default_conversation._Conversation__rememberer, "schedule_conversation_state", lambda *args, **kwargs: scheduled.append((args, kwargs)))
+        default_conversation._Conversation__save_conversation(is_reload=False)
+        assert scheduled
 
-        with caplog.at_level(logging.INFO, logger="Mantella"):
-            default_conversation._Conversation__save_conversation(is_reload=False)
-
-        assert not any(self.SUMMARY_DISABLED_LOG in m for m in caplog.messages)
-        assert any(self.SUMMARY_ATTEMPTED_LOG in m for m in caplog.messages)
-
-    def test_reload_ignores_summary_disabled(self, default_conversation: Conversation, default_config: ConfigLoader, caplog):
-        """Even when conversation_summary_enabled is False, reload saves should still proceed."""
+    def test_reload_ignores_summary_disabled(self, default_conversation: Conversation, default_config: ConfigLoader, monkeypatch):
+        """Even when summaries are disabled, reload saves should still be scheduled."""
         default_config.conversation_summary_enabled = False
+        scheduled = []
+        monkeypatch.setattr(default_conversation._Conversation__rememberer, "schedule_conversation_state", lambda *args, **kwargs: scheduled.append((args, kwargs)))
+        default_conversation._Conversation__save_conversation(is_reload=True)
+        assert scheduled
 
-        with caplog.at_level(logging.INFO, logger="Mantella"):
-            default_conversation._Conversation__save_conversation(is_reload=True)
 
-        assert not any(self.SUMMARY_DISABLED_LOG in m for m in caplog.messages)
-        assert any(self.SUMMARY_ATTEMPTED_LOG in m for m in caplog.messages)
+class TestAsyncSummaryScheduling:
+    def test_slow_summary_does_not_block_following_work(self, default_config: ConfigLoader, default_rememberer: Summaries, example_skyrim_npc_character: Character):
+        """A transition can continue while its summary worker is still waiting on the LLM."""
+        thread = message_thread(default_config, "system prompt")
+        characters = Characters()
+        characters.add_or_update_character(example_skyrim_npc_character, len(thread))
+        started = threading.Event()
+        release = threading.Event()
+        persisted = threading.Event()
 
+        def slow_save(*args, **kwargs):
+            started.set()
+            assert release.wait(2)
+            persisted.set()
+
+        default_rememberer.save_conversation_state = slow_save
+        future = default_rememberer.schedule_conversation_state(
+            thread, [example_skyrim_npc_character], characters, "world", is_reload=True
+        )
+
+        assert started.wait(1)
+        dialogue_started = threading.Event()
+        dialogue_started.set()
+        assert dialogue_started.is_set()
+        assert not persisted.is_set()
+
+        release.set()
+        future.result(timeout=2)
+        assert persisted.is_set()
+        default_rememberer.shutdown(wait=True)
+
+    def test_summary_job_uses_an_isolated_snapshot(self, default_config: ConfigLoader, default_rememberer: Summaries, example_skyrim_npc_character: Character):
+        """Later active-turn mutations cannot change an already scheduled summary input."""
+        thread = message_thread(default_config, "system prompt")
+        thread.add_message(UserMessage(default_config, "before scheduling", "Player"))
+        characters = Characters()
+        characters.add_or_update_character(example_skyrim_npc_character, len(thread))
+        started = threading.Event()
+        release = threading.Event()
+        captured = []
+
+        def capture_save(messages, *args, **kwargs):
+            started.set()
+            assert release.wait(2)
+            captured.append([message.text for message in messages.get_talk_only() if isinstance(message, UserMessage)])
+
+        default_rememberer.save_conversation_state = capture_save
+        future = default_rememberer.schedule_conversation_state(
+            thread, [example_skyrim_npc_character], characters, "world", is_reload=True
+        )
+        assert started.wait(1)
+        thread.add_message(UserMessage(default_config, "after scheduling", "Player"))
+        release.set()
+        future.result(timeout=2)
+
+        assert captured == [["before scheduling"]]
+        default_rememberer.shutdown(wait=True)
 
 class TestEdgeCases:
     def test_empty_conversation(self, default_config: ConfigLoader, default_rememberer: Summaries):

--- a/tests/test_characters_manager.py
+++ b/tests/test_characters_manager.py
@@ -47,6 +47,31 @@ class TestNearbyNPCs:
         
         assert chars.get_nearby_npc_names() == []
 
+    def test_same_display_name_actors_remain_distinct(self, example_skyrim_npc_character: Character):
+        first = example_skyrim_npc_character
+        second = Character(
+            base_id=first.base_id, ref_id="0799F8", name=first.name,
+            gender_raw=first.gender_raw, race_raw=first.race_raw,
+            is_player_character=False, bio=first.bio,
+            is_in_combat=False, is_enemy=False, relationship_rank=0,
+            is_generic_npc=True, ingame_voice_model=first.in_game_voice_model,
+            tts_voice_model=first.tts_voice_model,
+            csv_in_game_voice_model=first.csv_in_game_voice_model,
+            advanced_voice_model=first.advanced_voice_model,
+            voice_accent=first.voice_accent, equipment=first.equipment,
+            custom_character_values={},
+        )
+        first.ref_id = "0799F9"
+        chars = Characters()
+        chars.add_or_update_character(first)
+        chars.add_or_update_character(second)
+        assert chars.active_character_count() == 2
+        assert chars.get_character_by_ref_id("0799F9") is first
+        assert chars.get_character_by_ref_id("0799F8") is second
+        chars.remove_character(first)
+        assert chars.active_character_count() == 1
+        assert chars.get_character_by_ref_id("0799F8") is second
+
 
 class TestGetAllNamesWithNearby:
     """Test the unified get_all_names_w_nearby method with various scopes"""

--- a/tests/test_game_manager.py
+++ b/tests/test_game_manager.py
@@ -168,3 +168,27 @@ def test_sentence_to_json_with_empty_actions(default_game_manager: GameStateMana
     
     assert comm_consts.KEY_ACTOR_ACTIONS in result
     assert result[comm_consts.KEY_ACTOR_ACTIONS] == []
+
+
+def test_sentence_to_json_includes_stable_speaker_ref_id(default_game_manager: GameStateManager, example_skyrim_npc_character: Character):
+    content = SentenceContent(
+        speaker=example_skyrim_npc_character,
+        text="Hello there.",
+        sentence_type=SentenceTypeEnum.SPEECH,
+    )
+    result = default_game_manager.sentence_to_json(Sentence(content, "test.wav", 1.0), topicID=1)
+
+    assert result[comm_consts.KEY_ACTOR_SPEAKER] == example_skyrim_npc_character.name
+    assert result[comm_consts.KEY_ACTOR_REFID] == int(example_skyrim_npc_character.ref_id, 16)
+
+
+def test_generic_npc_speaker_payload_preserves_ref_id(default_game_manager: GameStateManager, example_skyrim_npc_character: Character):
+    example_skyrim_npc_character.name = "Wood Elf"
+    example_skyrim_npc_character.ref_id = "000EFD"
+    example_skyrim_npc_character.is_generic_npc = True
+    content = SentenceContent(example_skyrim_npc_character, "Greetings.", SentenceTypeEnum.SPEECH)
+
+    result = default_game_manager.sentence_to_json(Sentence(content, "test.wav", 1.0), topicID=1)
+
+    assert result[comm_consts.KEY_ACTOR_SPEAKER] == "Wood Elf"
+    assert result[comm_consts.KEY_ACTOR_REFID] == int("000EFD", 16)


### PR DESCRIPTION
### Problem

Rapid conversation and participant transitions could allow teardown or stale lifecycle work to terminate the active conversation, causing recognized player speech to be lost before its text-bearing request reached Mantella.

### Fix

- Makes conversation teardown idempotent and preserves detached closed-conversation summary/persistence state.
- Defers route reinitialization while a conversation is active.
- Adds conversation-session ownership to lifecycle requests and rejects mismatched stale non-start requests while preserving intended legacy requests without a session.
- Defers participant refreshes rather than cancelling an accepted in-flight dialogue generation.
- Tracks participants by stable actor/ref ID instead of display name, keeping duplicate-name actors distinct.
- Uses immutable participant snapshots for in-flight generation and stable actor identity for summary targeting.
- Persists transition summaries asynchronously so participant changes do not block the next dialogue request.
- Adds optional `mantella_actor_refid` to NPC speech payloads for exact speaker routing.

### Protocol and companion Papyrus behavior

The companion Papyrus implementation is [Mantella-Spell PR #151](https://github.com/art-from-the-machine/Mantella-Spell/pull/151). The actor-ref field is optional and backward-compatible: older Mantella-Spell versions ignore it and retain legacy routing. Exact duplicate-name physical-speaker routing requires the companion Papyrus behavior, but #745 remains functional without it.

### Validation

Before, live tracing showed:

`STT recognized “Are you ready?” → end request arrived → active conversation cleared → text-bearing input never reached the NPC.`

Live validation confirmed that same-name Stormcloak actors remain distinct, participant replacement no longer swallows the first response, and asynchronous summary work continues without cancelling accepted dialogue generation. With #151 paired, the correct same-name physical Stormcloak actor speaks, and generic Wood Elf playback works through the safe unique-name fallback.

Focused lifecycle, identity, summary, and route-guard tests, Python compilation, and `git diff --check` passed.
