### PR TITLE
Fix Unicode output in conversation logs

### DIFF
--- a/src/conversation/conversation_log.py
+++ b/src/conversation/conversation_log.py
@@ -32,7 +32,7 @@ class conversation_log:
                 conversation_history = [messages] # wrap the first conversation in a list
             
             with open(conversation_history_file, 'w', encoding='utf-8') as f:
-                json.dump(conversation_history, f, indent=4) # save everything except the initial system prompt
+                json.dump(conversation_history, f, indent=4, ensure_ascii=False) # save everything except the initial system prompt
 
     @staticmethod   
     @utils.time_it 

--- a/tests/conversation/test_conversation_log.py
+++ b/tests/conversation/test_conversation_log.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+from src.conversation.conversation_log import conversation_log
+
+
+def test_save_conversation_log_does_not_escape_unicode(tmp_path, monkeypatch):
+    monkeypatch.setattr(conversation_log, "game_path", str(tmp_path))
+
+    character = SimpleNamespace(name="Lydia", ref_id="000A2C8E")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "こんにちは 안녕하세요 Привет",
+        }
+    ]
+
+    conversation_log.save_conversation_log(character, messages, "test-world")
+
+    log_files = list(tmp_path.rglob("*.json"))
+    assert len(log_files) == 1
+
+    saved_text = log_files[0].read_text(encoding="utf-8")
+
+    assert "こんにちは" in saved_text
+    assert "안녕하세요" in saved_text
+    assert "Привет" in saved_text


### PR DESCRIPTION
## Summary

- Write conversation logs with `ensure_ascii=False`
- Preserve non-ASCII characters in their readable form
- Add a regression test covering Japanese, Korean, and Cyrillic text

Fixes art-from-the-machine/Mantella#739

## Testing

- `pytest tests/conversation/test_conversation_log.py -q`
- `pytest --tb=short -q -m "not requires_audio and not requires_external_exe and not requires_llm"`

Result: 632 passed, 24 skipped, 28 deselected.