### PR TITLE
Preserve underlying LLM API connection errors

### DIFF
--- a/src/llm/client_base.py
+++ b/src/llm/client_base.py
@@ -244,6 +244,8 @@ class ClientBase(AIClient):
             with self._generation_lock:
                 logger.log(28, 'Getting LLM response...')
 
+                async_client: AsyncOpenAI | None = None # initialize a vatiable before using in the try/finally block
+
                 if self._request_params:
                     request_params = self._request_params.copy() # copy of self._request_params to allow temporary override
                 else:
@@ -353,7 +355,7 @@ class ClientBase(AIClient):
                                 service_connection_attempt = 'OpenAI' # check if player means to connect to OpenAI
                             logger.error(f"Invalid API key. If you are trying to connect to {service_connection_attempt}, please choose an {service_connection_attempt} model via the 'model' setting in MantellaSoftware/config.ini. If you are instead trying to connect to a local model, please ensure the service is running.")
                         else:
-                            logger.error(f"LLM API Error: {e}")
+                            logger.error(f"LLM API Error: {e}; \ncause: {e.__cause__}", exc_info=True)
                     elif isinstance(e, BadRequestError):
                         if (e.type == 'invalid_request_error') and (self._image_client): # invalid request
                             logger.error(f"Invalid request. Try disabling Vision in Mantella's settings and try again.")

--- a/tests/llm/test_llm_client.py
+++ b/tests/llm/test_llm_client.py
@@ -1,5 +1,8 @@
 from src.llm.llm_client import LLMClient
+import logging
+import httpx
 import pytest
+from openai import APIConnectionError
 from src.config.config_loader import ConfigLoader
 import src.llm.client_base
 from src.llm.messages import SystemMessage
@@ -118,6 +121,41 @@ async def test_async_call(llm_client: LLMClient, example_system_message: SystemM
                 response += item
     assert response is not None
     assert isinstance(response, str)
+
+
+@pytest.mark.asyncio
+async def test_streaming_call_logs_connection_cause_when_client_creation_fails(
+    llm_client: LLMClient,
+    example_system_message: SystemMessage,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+):
+    """A client creation error must not be masked by an unbound local error."""
+    await llm_client._startup_async_client.close()
+    llm_client._startup_async_client = None
+
+    request = httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions")
+
+    def raise_connection_error():
+        try:
+            raise httpx.ConnectError("simulated connection failure", request=request)
+        except httpx.ConnectError as cause:
+            raise APIConnectionError(request=request) from cause
+
+    monkeypatch.setattr(llm_client, "generate_async_client", raise_connection_error)
+    monkeypatch.setattr("src.utils.play_error_sound", lambda: None)
+
+    with caplog.at_level(logging.ERROR, logger="Mantella"):
+        result = [
+            item
+            async for item in llm_client.streaming_call(
+                messages=example_system_message,
+                is_multi_npc=False,
+            )
+        ]
+
+    assert result == []
+    assert "simulated connection failure" in caplog.text
 
 
 def test_assistant_message_tool_calls_serialization(default_config: ConfigLoader):


### PR DESCRIPTION
## Summary

- Initialize `async_client` before entering the `try/finally` block
- Prevent `UnboundLocalError` from masking failures that occur before the async client is created
- Log the underlying cause and traceback for `APIConnectionError`
- Add a regression test that simulates an OpenRouter connection failure

Related to #742

## Testing

- `pytest tests/llm/test_llm_client.py -q -k "streaming_call_logs_connection_cause_when_client_creation_fails"`

Result: 1 passed.